### PR TITLE
chore: host assets directly with cloudflare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,14 +514,11 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "http",
- "include_dir",
  "leptos",
  "leptos_axum",
  "leptos_meta",
  "leptos_router",
  "log",
- "mime",
- "mime_guess",
  "reqwest",
  "serde_json",
  "tower 0.5.1",
@@ -874,25 +871,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -1281,16 +1259,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -2423,15 +2391,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
-]
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ leptos_router = "0.6"
 wasm-bindgen = "0.2"
 console_log = "1"
 log = "0.4"
-include_dir = { version = "0.7", optional = true }
-mime = { version = "0.3", optional = true }
-mime_guess = { version = "2", optional = true }
 reqwest = { version = "0.12", features = ["json"] }
 serde_json = "1"
 
@@ -39,9 +36,6 @@ ssr = [
   "leptos_axum/wasm",
   "leptos_meta/ssr",
   "leptos_router/ssr",
-  "dep:include_dir",
-  "dep:mime",
-  "dep:mime_guess",
   "dep:worker",
   "dep:worker-macros",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,8 @@ pub fn App() -> impl IntoView {
     );
 
     view! {
-        <Stylesheet href="/pkg/style.css"/>
-        <Link rel="icon" type_="image/x-icon" href="/pkg/favicon.ico"/>
+        <Stylesheet href="/style.css"/>
+        <Link rel="icon" type_="image/x-icon" href="/favicon.ico"/>
         <h1 class="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl">Forest Explorer</h1>
         <select on:change=move |ev| {
             rpc_provider.set(event_target_value(&ev))
@@ -110,32 +110,10 @@ pub fn hydrate() {
 #[cfg(feature = "ssr")]
 mod ssr_imports {
     use crate::App;
-    use axum::http::{HeaderValue, StatusCode};
-    use axum::{
-        extract::Path,
-        response::IntoResponse,
-        routing::{get, post},
-        Router,
-    };
-    use include_dir::{include_dir, Dir};
+    use axum::{routing::post, Router};
     use leptos::*;
     use leptos_axum::{generate_route_list, LeptosRoutes};
     use worker::{event, Context, Env, HttpRequest, Result};
-
-    static PKG_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/pkg/");
-
-    async fn serve_static(Path(path): Path<String>) -> impl IntoResponse {
-        let mime_type = mime_guess::from_path(&path).first_or_text_plain();
-        let mut headers = axum::http::HeaderMap::new();
-        headers.insert(
-            axum::http::header::CONTENT_TYPE,
-            HeaderValue::from_str(mime_type.as_ref()).unwrap(),
-        );
-        match PKG_DIR.get_file(path) {
-            None => (StatusCode::NOT_FOUND, headers, "File not found.".as_bytes()),
-            Some(file) => (StatusCode::OK, headers, file.contents()),
-        }
-    }
 
     fn router() -> Router {
         let leptos_options = LeptosOptions::builder()
@@ -148,7 +126,6 @@ mod ssr_imports {
         let app: axum::Router<()> = Router::new()
             .leptos_routes(&leptos_options, routes, App)
             .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
-            .route("/pkg/*file_name", get(serve_static))
             .with_state(leptos_options);
         app
     }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,9 +4,25 @@ compatibility_date = "2024-07-13"
 # ChainSafe Static Hosting
 account_id = '2238a825c5aca59233eab1f221f7aefb'
 
-routes = [
-	{ pattern = "forest-explorer.chainsafe.dev", custom_domain = true }
-]
+routes = [{ pattern = "forest-explorer.chainsafe.dev", custom_domain = true }]
+
+[assets]
+directory = "assets"
 
 [build]
-command = "mkdir -p pkg && cp public/* pkg/ && npx tailwindcss --minify -i style/tailwind.css -o pkg/style.css && wasm-pack build --no-typescript --release --target web --out-name client --features hydrate --no-default-features && worker-build --release --features ssr --no-default-features"
+command = """
+mkdir -p assets/pkg &&
+cp public/* assets/ &&
+npx tailwindcss --minify -i style/tailwind.css -o assets/style.css &&
+wasm-pack build --out-dir assets/pkg --release --no-typescript --target web --out-name client --features hydrate --no-default-features &&
+worker-build --release --features ssr --no-default-features
+"""
+
+[env.quick.build]
+command = """
+mkdir -p assets/pkg &&
+cp public/* assets/ &&
+npx tailwindcss --minify -i style/tailwind.css -o assets/style.css &&
+wasm-pack build --out-dir assets/pkg --no-opt --no-typescript --target web --out-name client --features hydrate --no-default-features &&
+worker-build --no-opt --features ssr --no-default-features
+"""


### PR DESCRIPTION
Host static assets with CloudFlare rather than embedding them into our WASM bundle. Also, add `quick` env for faster iterations.

Closes: #49