### PR TITLE
fix: don't report pending transactions as errors

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -127,14 +127,15 @@ pub fn Faucet() -> impl IntoView {
                 .collect::<Vec<_>>();
             spawn_local(catch_all(error_messages, async move {
                 for cid in pending {
-                    let lookup = rpc_context.get_untracked().state_search_msg(cid).await?;
-                    sent_messages.update(|messages| {
-                        for (cid, sent) in messages {
-                            if cid == &lookup.message {
-                                *sent = true;
+                    if let Some(lookup) = rpc_context.get_untracked().state_search_msg(cid).await? {
+                        sent_messages.update(|messages| {
+                            for (cid, sent) in messages {
+                                if cid == &lookup.message {
+                                    *sent = true;
+                                }
                             }
-                        }
-                    });
+                        });
+                    }
                 }
                 Ok(())
             }));

--- a/src/rpc_context.rs
+++ b/src/rpc_context.rs
@@ -150,7 +150,7 @@ impl Provider {
     }
 
     #[cfg(feature = "hydrate")]
-    pub async fn state_search_msg(&self, msg: Cid) -> anyhow::Result<MessageLookup> {
+    pub async fn state_search_msg(&self, msg: Cid) -> anyhow::Result<Option<MessageLookup>> {
         invoke_rpc_method(
             &self.url,
             "Filecoin.StateSearchMsg",


### PR DESCRIPTION
`StateSearchMsg` may return `null`. If this happens, don't report it as an error.