### PR TITLE
fix: transactional rate-limiter

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -81,7 +81,9 @@ pub fn Faucet() -> impl IntoView {
 
     let rpc_context = RpcContext::use_context();
 
+    // Disable the send button while we're asking the RPC provider for the nonce
     let send_button_disabled = create_rw_signal(false);
+    // Disable the send button if rate-limited
     let send_button_limited = create_rw_signal(0);
 
     #[cfg(feature = "hydrate")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ mod faucet;
 mod key;
 mod lotus_json;
 mod message;
+#[cfg(feature = "ssr")]
+mod rate_limiter;
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,0 +1,40 @@
+use chrono::{DateTime, Duration, Utc};
+use worker::*;
+
+const LIMIT_SECONDS: i64 = 30;
+
+#[durable_object]
+pub struct RateLimiter {
+    state: State,
+    block_until: DateTime<Utc>,
+}
+
+#[durable_object]
+impl DurableObject for RateLimiter {
+    fn new(state: State, _env: Env) -> Self {
+        Self {
+            state,
+            block_until: Utc::now(),
+        }
+    }
+
+    async fn fetch(&mut self, _req: Request) -> Result<Response> {
+        let now = Utc::now();
+        if self.block_until <= now {
+            // This Durable Object will be deleted after the alarm is triggered
+            self.state
+                .storage()
+                .set_alarm(std::time::Duration::from_secs(LIMIT_SECONDS as u64 + 1))
+                .await?;
+            self.block_until = now + Duration::seconds(LIMIT_SECONDS);
+
+            Response::from_json(&true)
+        } else {
+            Response::from_json(&false)
+        }
+    }
+
+    async fn alarm(&mut self) -> Result<Response> {
+        Response::ok("OK")
+    }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,9 +6,12 @@ account_id = '2238a825c5aca59233eab1f221f7aefb'
 
 routes = [{ pattern = "forest-explorer.chainsafe.dev", custom_domain = true }]
 
-kv_namespaces = [
-    { binding = "RATE_LIMIT", id = "4dc6f9a495dc44849d2c3c9066f23dca" },
-]
+[durable_objects]
+bindings = [{ name = "RATE_LIMITER", class_name = "RateLimiter" }]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["RateLimiter"]
 
 [assets]
 directory = "assets"


### PR DESCRIPTION
 - Transactional rate-limiter. Cannot be defeated by rapid clicking!
 - Disable the "Send" button when preparing the Filecoin transaction.
 - Disable the "Send" button when rate limited.