### PR TITLE
Fix flickering 

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -49,20 +49,20 @@ pub fn BlockchainExplorer() -> impl IntoView {
             <option value="https://api.node.glif.io/">Glif.io Mainnet</option>
         </select>
         <p>StateNetworkName</p>
-        <Suspense fallback={move || view!{ <p>Loading network name...</p> }}>
+        <Transition fallback={move || view!{ <p>Loading network name...</p> }}>
             <p class="px-8">
                 <span>{move || network_name.get().as_deref().flatten().cloned()}</span>
                 <Loader loading={move || network_name.get().is_none()} />
             </p>
-        </Suspense>
+        </Transition>
 
         <p>StateNetworkVersion</p>
-        <Suspense fallback={move || view!{ <p>Loading network version...</p> }}>
+        <Transition fallback={move || view!{ <p>Loading network version...</p> }}>
             <p class="px-8">
                 <span>{move || network_version.get().as_deref().flatten().cloned()}</span>
                 <Loader loading={move || network_version.get().is_none()} />
             </p>
-        </Suspense>
+        </Transition>
     }
 }
 

--- a/src/faucet/controller.rs
+++ b/src/faucet/controller.rs
@@ -23,6 +23,7 @@ impl FaucetController {
         let balance_trigger = Trigger::new();
         let target_balance = LocalResource::new(move || {
             let target_address = target_address.get();
+            balance_trigger.track();
             async move {
                 if let Ok(address) = parse_address(&target_address, network) {
                     Provider::from_network(network)
@@ -35,14 +36,11 @@ impl FaucetController {
                 }
             }
         });
-        let sender_address = LocalResource::new(move || {
-            balance_trigger.track();
-            async move {
-                faucet_address(is_mainnet)
-                    .await
-                    .map(|LotusJson(addr)| addr)
-                    .ok()
-            }
+        let sender_address = LocalResource::new(move || async move {
+            faucet_address(is_mainnet)
+                .await
+                .map(|LotusJson(addr)| addr)
+                .ok()
         });
         let faucet_balance = LocalResource::new(move || {
             balance_trigger.track();

--- a/src/faucet/views.rs
+++ b/src/faucet/views.rs
@@ -118,15 +118,15 @@ pub fn Faucet(target_network: Network) -> impl IntoView {
             <div class="flex justify-between my-4">
                 <div>
                     <h3 class="text-lg font-semibold">Faucet Balance:</h3>
-                    <Suspense fallback={move || view!{ <p>Loading faucet balance...</p> }}>
+                    <Transition fallback={move || view!{ <p>Loading faucet balance...</p> }}>
                         <p class="text-xl">{ move || format_balance(&faucet.get().get_faucet_balance(), &faucet.get().get_fil_unit()) }</p>
-                    </Suspense>
+                    </Transition>
                 </div>
                 <div>
                     <h3 class="text-lg font-semibold">Target Balance:</h3>
-                    <Suspense fallback={move || view!{ <p>Loading target balance...</p> }}>
+                    <Transition fallback={move || view!{ <p>Loading target balance...</p> }}>
                         <p class="text-xl">{ move || format_balance(&faucet.get().get_target_balance(), &faucet.get().get_fil_unit()) }</p>
-                    </Suspense>
+                    </Transition>
                 </div>
             </div>
             <hr class="my-4 border-t border-gray-300" />


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Use `Transition` instead of `Suspense` to avoid flickering back to "Loading..."
- Fixed flicker between faucet actual balance and empty balance
- Update target balance also once transaction is confirmed

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #116 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),

<!-- Thank you 🔥 -->
