### PR TITLE
fix: address test data race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
  "multihash-codetable",
  "num-traits",
  "reqwest",
+ "rusty-fork",
  "send_wrapper",
  "serde",
  "serde_json",
@@ -2509,6 +2510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2895,6 +2902,18 @@ name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3887,6 +3906,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ wasm-bindgen = "0.2"
 worker = { version = "0.5", features = ['http', 'axum'], optional = true }
 worker-macros = { version = "0.5", features = ['http'], optional = true }
 
+[dev-dependencies]
+rusty-fork = "0.3.0"
+
 [features]
 hydrate = ["leptos/hydrate"]
 ssr = [

--- a/src/address.rs
+++ b/src/address.rs
@@ -83,6 +83,7 @@ mod tests {
     }
     }
 
+    rusty_fork_test! {
     #[test]
     fn test_parse_testnet_address() {
         let addr_str = "t410f2oekwcmo2pueydmaq53eic2i62crtbeyuzx2gmy";
@@ -90,6 +91,7 @@ mod tests {
 
         set_current_network(Network::Testnet); // Required to correctly stringify address
         assert_eq!(addr.to_string(), addr_str);
+    }
     }
 
     #[test]
@@ -103,7 +105,6 @@ mod tests {
         assert_eq!(err.to_string(), "Not a valid Mainnet address");
     }
 
-    rusty_fork_test! {
     #[test]
     fn test_parse_eth_address_testnet() {
         let addr_str = "0xd388ab098ed3e84c0d808776440b48f685198498";
@@ -113,7 +114,6 @@ mod tests {
         let exp_addr = parse_address(exp_addr_str, Network::Testnet).unwrap();
 
         assert_eq!(exp_addr, addr);
-    }
     }
 
     #[test]

--- a/src/address.rs
+++ b/src/address.rs
@@ -40,7 +40,12 @@ pub fn parse_address(raw: &str, n: Network) -> anyhow::Result<Address> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Whenever we change the network in tests, we need to fork the test to avoid
+    // changing the network for other tests. This is because the network is a global
+    // variable. This is not a problem when run with `cargo nextest` because each test
+    // is run separately.
     use fvm_shared::address::set_current_network;
+    use rusty_fork::rusty_fork_test;
 
     #[test]
     fn test_check_address_prefix() {
@@ -67,6 +72,7 @@ mod tests {
         assert!(!is_valid_prefix("456...", Network::Testnet));
     }
 
+    rusty_fork_test! {
     #[test]
     fn test_parse_mainnet_address() {
         let addr_str = "f1alg2sxw32ns3ech2w7r3dmp2gl2fputkl7x7jta";
@@ -74,6 +80,7 @@ mod tests {
 
         set_current_network(Network::Mainnet); // Required to correctly stringify address
         assert_eq!(addr.to_string(), addr_str);
+    }
     }
 
     #[test]
@@ -96,6 +103,7 @@ mod tests {
         assert_eq!(err.to_string(), "Not a valid Mainnet address");
     }
 
+    rusty_fork_test! {
     #[test]
     fn test_parse_eth_address_testnet() {
         let addr_str = "0xd388ab098ed3e84c0d808776440b48f685198498";
@@ -105,6 +113,7 @@ mod tests {
         let exp_addr = parse_address(exp_addr_str, Network::Testnet).unwrap();
 
         assert_eq!(exp_addr, addr);
+    }
     }
 
     #[test]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- this fixes a datarace in tests. It can be reproduced by running `cargo test` repeatedly in a loop, e.g., 50 iterations.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
