### PR TITLE
fix: bump openssl version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.96",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2255,9 +2255,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -2287,9 +2287,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- fixes `openssl` vulnerability reported by `cargo deny` and blocking the CI

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

```
error[vulnerability]: ssl::select_next_proto use after free
    ┌─ /home/rumcajs/prj/forest-explorer/Cargo.lock:192:1
    │
192 │ openssl 0.10.68 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
    │
    ├ ID: RUSTSEC-2025-0004
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0004
    ├ In `openssl` versions before `0.10.70`, `ssl::select_next_proto` can return a slice pointing into the `server` argument's buffer but with a lifetime bound to the `client` argument. In situations where the `server` buffer's lifetime is shorter than the `client` buffer's, this can cause a use after free. This could cause the server to crash or to return arbitrary memory contents to the client.

      `openssl` 0.10.70 fixes the signature of `ssl::select_next_proto` to properly constrain the output buffer's lifetime to that of both input buffers.

      In standard usage of `ssl::select_next_proto` in the callback passed to `SslContextBuilder::set_alpn_select_callback`, code is only affected if the `server` buffer is constructed *within* the callback. For example:

      Not vulnerable - the server buffer has a `'static` lifetime:
      ```rust
      builder.set_alpn_select_callback(|_, client_protos| {
          ssl::select_next_proto(b"\x02h2", client_protos).ok_or_else(AlpnError::NOACK)
      });
      ```

      Not vulnerable - the server buffer outlives the handshake:
      ```rust
      let server_protos = b"\x02h2".to_vec();
      builder.set_alpn_select_callback(|_, client_protos| {
          ssl::select_next_proto(&server_protos, client_protos).ok_or_else(AlpnError::NOACK)
      });
      ```

      Vulnerable - the server buffer is freed when the callback returns:
      ```rust
      builder.set_alpn_select_callback(|_, client_protos| {
          let server_protos = b"\x02h2".to_vec();
          ssl::select_next_proto(&server_protos, client_protos).ok_or_else(AlpnError::NOACK)
      });
      ```
    ├ Announcement: https://github.com/sfackler/rust-openssl/security/advisories/GHSA-rpmj-rpgj-qmpm
    ├ Solution: Upgrade to >=0.10.70 (try `cargo update -p openssl`)
    ├ openssl v0.10.68
      └── native-tls v0.2.12
          ├── hyper-tls v0.6.0
          │   └── reqwest v0.12.12
          │       └── forest-explorer v0.1.0
          ├── reqwest v0.12.12 (*)
          └── tokio-native-tls v0.3.1
              ├── hyper-tls v0.6.0 (*)
              └── reqwest v0.12.12 (*)

```

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
