### PR TITLE
fix: store 'block_until' in persistent storage

### DIFF
--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -4,7 +4,7 @@ use worker::*;
 #[durable_object]
 pub struct RateLimiter {
     state: State,
-    block_until: DateTime<Utc>,
+    _block_until: DateTime<Utc>,
 }
 
 #[durable_object]
@@ -12,19 +12,26 @@ impl DurableObject for RateLimiter {
     fn new(state: State, _env: Env) -> Self {
         Self {
             state,
-            block_until: Utc::now(),
+            _block_until: Utc::now(),
         }
     }
 
     async fn fetch(&mut self, _req: Request) -> Result<Response> {
         let now = Utc::now();
+        let block_until = self
+            .state
+            .storage()
+            .get("block_until")
+            .await
+            .map(|v| DateTime::<Utc>::from_timestamp(v, 0).unwrap_or_default())
+            .unwrap_or(Utc::now());
         console_log!(
             "Rate limiter invoked: now={:?}, block_until={:?}, may_sign={:?}",
             now,
-            self.block_until,
-            self.block_until <= now
+            block_until,
+            block_until <= now
         );
-        if self.block_until <= now {
+        if block_until <= now {
             // This Durable Object will be deleted after the alarm is triggered
             self.state
                 .storage()
@@ -32,7 +39,11 @@ impl DurableObject for RateLimiter {
                     crate::constants::RATE_LIMIT_SECONDS as u64 + 1,
                 ))
                 .await?;
-            self.block_until = now + Duration::seconds(crate::constants::RATE_LIMIT_SECONDS);
+            let block_until = now + Duration::seconds(crate::constants::RATE_LIMIT_SECONDS);
+            self.state
+                .storage()
+                .put("block_until", block_until.timestamp())
+                .await?;
 
             Response::from_json(&true)
         } else {

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -4,7 +4,8 @@ use worker::*;
 #[durable_object]
 pub struct RateLimiter {
     state: State,
-    _block_until: DateTime<Utc>,
+    #[allow(unused)]
+    block_until: DateTime<Utc>,
 }
 
 #[durable_object]
@@ -12,7 +13,7 @@ impl DurableObject for RateLimiter {
     fn new(state: State, _env: Env) -> Self {
         Self {
             state,
-            _block_until: Utc::now(),
+            block_until: Utc::now(),
         }
     }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- The Durable Object is clearing out its in-memory state more often than I expected. This PR moves the state into persistent storage.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
