### PR TITLE
Request faucet top-up on low balance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ env:
   RUSTC_WRAPPER: sccache
   CC: sccache clang
   CXX: sccache clang++
+  FAUCET_TOPUP_REQ_URL: '${{ vars.FAUCET_TOPUP_REQ_URL }}'
 
 jobs:
   deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@
 
 ### Added
 
-- [#135] (https://github.com/ChainSafe/forest-explorer/pull/135) Added option to
-  request for faucet top-up.
+- [#135] (https://github.com/ChainSafe/forest-explorer/pull/135) Added link to
+  request for faucet top-up which is configurable using github env var.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 
 ### Added
 
+- [#135] (https://github.com/ChainSafe/forest-explorer/pull/135) Added option to
+  request for faucet top-up.
+
 ### Changed
 
 ### Removed

--- a/src/faucet/views.rs
+++ b/src/faucet/views.rs
@@ -44,8 +44,7 @@ pub fn Faucet(target_network: Network) -> impl IntoView {
         Network::Mainnet => crate::constants::MAINNET_DRIP_AMOUNT.clone(),
         Network::Testnet => crate::constants::CALIBNET_DRIP_AMOUNT.clone(),
     };
-    let topup_req_url =
-        std::env::var("FAUCET_TOPUP_REQ_URL").expect("Faucet Top-up request url not set");
+    let topup_req_url = option_env!("FAUCET_TOPUP_REQ_URL");
     view! {
         {move || {
             let errors = faucet.get().get_error_messages();
@@ -144,7 +143,7 @@ pub fn Faucet(target_network: Network) -> impl IntoView {
                         }.into_any()
                     } else if faucet.get().get_faucet_balance() < drip_amount {
                         view! {
-                            <a href={topup_req_url.clone()} target="_blank" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-r">
+                            <a href={topup_req_url} target="_blank" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-r">
                                 "Request Faucet Top-up"
                             </a>
                         }.into_any()

--- a/src/faucet/views.rs
+++ b/src/faucet/views.rs
@@ -13,6 +13,7 @@ use leptos_use::*;
 use crate::faucet::controller::FaucetController;
 use crate::faucet::utils::format_balance;
 
+const FAUCET_TOPUP_REQ_URL: &str = "https://github.com/ChainSafe/forest-explorer/discussions/134";
 const MESSAGE_FADE_AFTER: Duration = Duration::new(3, 0);
 const MESSAGE_REMOVAL_AFTER: Duration = Duration::new(3, 500_000_000);
 
@@ -40,7 +41,10 @@ pub fn Faucet(target_network: Network) -> impl IntoView {
     );
 
     let (fading_messages, set_fading_messages) = signal(HashSet::new());
-
+    let drip_amount = match target_network {
+        Network::Mainnet => crate::constants::MAINNET_DRIP_AMOUNT.clone(),
+        Network::Testnet => crate::constants::CALIBNET_DRIP_AMOUNT.clone(),
+    };
     view! {
         {move || {
             let errors = faucet.get().get_error_messages();
@@ -136,6 +140,12 @@ pub fn Faucet(target_network: Network) -> impl IntoView {
                             <button class="bg-gray-400 text-white font-bold py-2 px-4 rounded-r" disabled=true>
                                 {format!("Rate-limited! {duration}s")}
                             </button>
+                        }.into_any()
+                    } else if faucet.get().get_faucet_balance() < drip_amount {
+                        view! {
+                            <a href={FAUCET_TOPUP_REQ_URL} target="_blank" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-r">
+                                "Request Faucet Top-up"
+                            </a>
                         }.into_any()
                     } else {
                         view! {

--- a/src/faucet/views.rs
+++ b/src/faucet/views.rs
@@ -13,7 +13,6 @@ use leptos_use::*;
 use crate::faucet::controller::FaucetController;
 use crate::faucet::utils::format_balance;
 
-const FAUCET_TOPUP_REQ_URL: &str = "https://github.com/ChainSafe/forest-explorer/discussions/134";
 const MESSAGE_FADE_AFTER: Duration = Duration::new(3, 0);
 const MESSAGE_REMOVAL_AFTER: Duration = Duration::new(3, 500_000_000);
 
@@ -45,6 +44,8 @@ pub fn Faucet(target_network: Network) -> impl IntoView {
         Network::Mainnet => crate::constants::MAINNET_DRIP_AMOUNT.clone(),
         Network::Testnet => crate::constants::CALIBNET_DRIP_AMOUNT.clone(),
     };
+    let topup_req_url =
+        std::env::var("FAUCET_TOPUP_REQ_URL").expect("Faucet Top-up request url not set");
     view! {
         {move || {
             let errors = faucet.get().get_error_messages();
@@ -143,7 +144,7 @@ pub fn Faucet(target_network: Network) -> impl IntoView {
                         }.into_any()
                     } else if faucet.get().get_faucet_balance() < drip_amount {
                         view! {
-                            <a href={FAUCET_TOPUP_REQ_URL} target="_blank" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-r">
+                            <a href={topup_req_url.clone()} target="_blank" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-r">
                                 "Request Faucet Top-up"
                             </a>
                         }.into_any()


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Show a `Request Faucet Top-up` option instead of send button if available faucet balance is less than network drip amount
![image](https://github.com/user-attachments/assets/e2cb472c-33b2-4529-bf74-2aa6659157fc)

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #129 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
