### PR TITLE
Revert "Different rate limiter for calibnet and mainnet (#142)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,6 @@
 
 - [#135] (https://github.com/ChainSafe/forest-explorer/pull/135) Added link to
   request for faucet top-up which is configurable using github env var.
-- [#137] (https://github.com/ChainSafe/forest-explorer/issues/137) Different
-  rate limitter for calibnet and mainnet
 
 ### Changed
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,8 +4,7 @@ use fvm_shared::econ::TokenAmount;
 
 /// The rate limit imposed by the CloudFlare's rate limiter, and also reflected in the user
 /// interface.
-pub const CALIBNET_RATE_LIMIT_SECONDS: i64 = 60;
-pub const MAINNET_RATE_LIMIT_SECONDS: i64 = 600;
+pub const RATE_LIMIT_SECONDS: i64 = 600;
 /// The amount of mainnet FIL to be dripped to the user. This corresponds to 0.01 FIL.
 pub static MAINNET_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_nano(10_000_000));

--- a/src/faucet/controller.rs
+++ b/src/faucet/controller.rs
@@ -6,12 +6,8 @@ use leptos::task::spawn_local;
 use uuid::Uuid;
 
 use crate::{
-    address::parse_address,
-    constants::{CALIBNET_RATE_LIMIT_SECONDS, MAINNET_RATE_LIMIT_SECONDS},
-    lotus_json::LotusJson,
-    message::message_transfer,
-    rpc_context::Provider,
-    utils::catch_all,
+    address::parse_address, lotus_json::LotusJson, message::message_transfer,
+    rpc_context::Provider, utils::catch_all,
 };
 
 use super::utils::faucet_address;
@@ -210,12 +206,9 @@ impl FaucetController {
                             }
                             Err(e) => {
                                 log::error!("Failed to sign message: {}", e);
-                                let rate_limit_seconds = if is_mainnet {
-                                    MAINNET_RATE_LIMIT_SECONDS
-                                } else {
-                                    CALIBNET_RATE_LIMIT_SECONDS
-                                } as i32;
-                                faucet.send_limited.set(rate_limit_seconds);
+                                faucet
+                                    .send_limited
+                                    .set(crate::constants::RATE_LIMIT_SECONDS as i32);
                             }
                         }
                         Ok(())

--- a/src/faucet/views.rs
+++ b/src/faucet/views.rs
@@ -235,7 +235,7 @@ pub fn Faucet_Calibnet() -> impl IntoView {
             <Faucet target_network=Network::Testnet />
         </div>
         <div class="text-center mt-4">
-            "This faucet distributes " { format_balance(&crate::constants::CALIBNET_DRIP_AMOUNT, crate::constants::FIL_CALIBNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::CALIBNET_RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
+            "This faucet distributes " { format_balance(&crate::constants::CALIBNET_DRIP_AMOUNT, crate::constants::FIL_CALIBNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
         </div>
     }
 }
@@ -249,7 +249,7 @@ pub fn Faucet_Mainnet() -> impl IntoView {
             <h1 class="text-4xl font-bold mb-6 text-center">Filecoin Mainnet Faucet</h1>
             <Faucet target_network=Network::Mainnet />
         <div class="text-center mt-4">
-            "This faucet distributes " { format_balance(&crate::constants::MAINNET_DRIP_AMOUNT, crate::constants::FIL_MAINNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::MAINNET_RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans or service termination. Faucet funds are limited and may run out. They are replenished periodically."
+            "This faucet distributes " { format_balance(&crate::constants::MAINNET_DRIP_AMOUNT, crate::constants::FIL_MAINNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans or service termination. Faucet funds are limited and may run out. They are replenished periodically."
         </div>
         </div>
     }


### PR DESCRIPTION
This reverts commit 7a327d3ca04b191d3e5053d3c84e2e8f82553f40.

## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- rate-limiting doesn't work correctly - I get rate limited on both calibnet and mainnet, even though both had last transaction over 2-3 days ago.

https://beryx.io/fil/calibration/address/t15ydyu3d65gznpp2qxwpkjsgz4waubeunn6upvla
https://beryx.io/fil/mainnet/address/f1j2al2ibxjpuy4ezamwd6exsftk6jlmqmdyivmui

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Re-opens https://github.com/ChainSafe/forest-explorer/issues/137

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
