### PR TITLE
Revive different rate limiter for mainnet and calibnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - [#135] (https://github.com/ChainSafe/forest-explorer/pull/135) Added link to
   request for faucet top-up which is configurable using github env var.
 
+- [#137] (https://github.com/ChainSafe/forest-explorer/issues/137) Different
+  rate limitter for calibnet and mainnet
+
 ### Changed
 
 - [#136](https://github.com/ChainSafe/forest-explorer/pull/136) Increased the

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,7 +4,8 @@ use fvm_shared::econ::TokenAmount;
 
 /// The rate limit imposed by the CloudFlare's rate limiter, and also reflected in the user
 /// interface.
-pub const RATE_LIMIT_SECONDS: i64 = 600;
+pub const CALIBNET_RATE_LIMIT_SECONDS: i64 = 60;
+pub const MAINNET_RATE_LIMIT_SECONDS: i64 = 600;
 /// The amount of mainnet FIL to be dripped to the user. This corresponds to 0.01 FIL.
 pub static MAINNET_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_nano(10_000_000));

--- a/src/faucet/controller.rs
+++ b/src/faucet/controller.rs
@@ -6,8 +6,12 @@ use leptos::task::spawn_local;
 use uuid::Uuid;
 
 use crate::{
-    address::parse_address, lotus_json::LotusJson, message::message_transfer,
-    rpc_context::Provider, utils::catch_all,
+    address::parse_address,
+    constants::{CALIBNET_RATE_LIMIT_SECONDS, MAINNET_RATE_LIMIT_SECONDS},
+    lotus_json::LotusJson,
+    message::message_transfer,
+    rpc_context::Provider,
+    utils::catch_all,
 };
 
 use super::utils::faucet_address;
@@ -206,9 +210,12 @@ impl FaucetController {
                             }
                             Err(e) => {
                                 log::error!("Failed to sign message: {}", e);
-                                faucet
-                                    .send_limited
-                                    .set(crate::constants::RATE_LIMIT_SECONDS as i32);
+                                let rate_limit_seconds = if is_mainnet {
+                                    MAINNET_RATE_LIMIT_SECONDS
+                                } else {
+                                    CALIBNET_RATE_LIMIT_SECONDS
+                                } as i32;
+                                faucet.send_limited.set(rate_limit_seconds);
                             }
                         }
                         Ok(())

--- a/src/faucet/utils.rs
+++ b/src/faucet/utils.rs
@@ -46,12 +46,18 @@ pub async fn sign_with_secret_key(
             .secret("RATE_LIMITER_DISABLED")
             .map(|v| v.to_string().to_lowercase() == "true")
             .unwrap_or(false);
-        let may_sign = rate_limiter_disabled || query_rate_limiter().await?;
+        let network = if is_mainnet { "mainnet" } else { "calibnet" };
+        let may_sign = rate_limiter_disabled || query_rate_limiter(network).await?;
+        let rate_limit_seconds = if is_mainnet {
+            crate::constants::MAINNET_RATE_LIMIT_SECONDS
+        } else {
+            crate::constants::CALIBNET_RATE_LIMIT_SECONDS
+        };
 
         if !may_sign {
             return Err(ServerFnError::ServerError(format!(
                 "Rate limit exceeded - wait {} seconds",
-                crate::constants::RATE_LIMIT_SECONDS
+                rate_limit_seconds
             )));
         }
 
@@ -96,7 +102,7 @@ pub async fn secret_key(network: Network) -> Result<Key, ServerFnError> {
 }
 
 #[cfg(feature = "ssr")]
-pub async fn query_rate_limiter() -> Result<bool, ServerFnError> {
+pub async fn query_rate_limiter(network: &str) -> Result<bool, ServerFnError> {
     use axum::Extension;
     use leptos_axum::extract;
     use std::sync::Arc;
@@ -105,10 +111,13 @@ pub async fn query_rate_limiter() -> Result<bool, ServerFnError> {
     let Extension(env): Extension<Arc<Env>> = extract().await?;
     let rate_limiter = env
         .durable_object("RATE_LIMITER")?
-        .id_from_name("RATE_LIMITER")?
+        .id_from_name(network)?
         .get_stub()?;
     Ok(rate_limiter
-        .fetch_with_request(Request::new("http://do/rate_limiter", Method::Get)?)
+        .fetch_with_request(Request::new(
+            &format!("http://do/rate_limiter/{}", network),
+            Method::Get,
+        )?)
         .await?
         .json::<bool>()
         .await?)

--- a/src/faucet/views.rs
+++ b/src/faucet/views.rs
@@ -235,7 +235,7 @@ pub fn Faucet_Calibnet() -> impl IntoView {
             <Faucet target_network=Network::Testnet />
         </div>
         <div class="text-center mt-4">
-            "This faucet distributes " { format_balance(&crate::constants::CALIBNET_DRIP_AMOUNT, crate::constants::FIL_CALIBNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
+        "This faucet distributes " { format_balance(&crate::constants::CALIBNET_DRIP_AMOUNT, crate::constants::FIL_CALIBNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::CALIBNET_RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
         </div>
     }
 }
@@ -249,7 +249,7 @@ pub fn Faucet_Mainnet() -> impl IntoView {
             <h1 class="text-4xl font-bold mb-6 text-center">Filecoin Mainnet Faucet</h1>
             <Faucet target_network=Network::Mainnet />
         <div class="text-center mt-4">
-            "This faucet distributes " { format_balance(&crate::constants::MAINNET_DRIP_AMOUNT, crate::constants::FIL_MAINNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans or service termination. Faucet funds are limited and may run out. They are replenished periodically."
+        "This faucet distributes " { format_balance(&crate::constants::MAINNET_DRIP_AMOUNT, crate::constants::FIL_MAINNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::MAINNET_RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans or service termination. Faucet funds are limited and may run out. They are replenished periodically."
         </div>
         </div>
     }

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -20,12 +20,11 @@ impl DurableObject for RateLimiter {
 
     async fn fetch(&mut self, req: Request) -> Result<Response> {
         let now = Utc::now();
-        let url = req.url()?;
-        let network = url.path().split('/').last().unwrap_or_default();
-        let rate_limit_seconds = match network {
-            "calibnet" => CALIBNET_RATE_LIMIT_SECONDS,
-            "mainnet" => MAINNET_RATE_LIMIT_SECONDS,
-            _ => return Err(worker::Error::RustError("Unknown network".into())),
+        let path = req.path();
+        let (network, rate_limit_seconds) = if path.contains("mainnet") {
+            ("mainnet", MAINNET_RATE_LIMIT_SECONDS)
+        } else {
+            ("calibnet", CALIBNET_RATE_LIMIT_SECONDS)
         };
         let storage_key = format!("block_until_{}", network);
         let block_until = self


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Fixed rate limiter issue with accessing network info from request path. 
[fix: ](https://github.com/ChainSafe/forest-explorer/pull/180/commits/3c6b61555628a5a730afc52c21918fb123594954) use `req.path()` instead of `req.url()`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #137 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
