### PR TITLE
Network based rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - [#135](https://github.com/ChainSafe/forest-explorer/pull/135) Added link to
   request for faucet top-up which is configurable using github env var.
 
+- [#137] (https://github.com/ChainSafe/forest-explorer/issues/137) Different
+  rate limitter for calibnet and mainnet
+
 ### Changed
 
 - [#136](https://github.com/ChainSafe/forest-explorer/pull/136) Increased the

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,7 +4,8 @@ use fvm_shared::econ::TokenAmount;
 
 /// The rate limit imposed by the CloudFlare's rate limiter, and also reflected in the user
 /// interface.
-pub const RATE_LIMIT_SECONDS: i64 = 600;
+pub const CALIBNET_RATE_LIMIT_SECONDS: i64 = 60;
+pub const MAINNET_RATE_LIMIT_SECONDS: i64 = 600;
 /// The amount of mainnet FIL to be dripped to the user. This corresponds to 0.01 FIL.
 pub static MAINNET_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_nano(10_000_000));

--- a/src/faucet/controller.rs
+++ b/src/faucet/controller.rs
@@ -6,8 +6,12 @@ use leptos::task::spawn_local;
 use uuid::Uuid;
 
 use crate::{
-    address::parse_address, lotus_json::LotusJson, message::message_transfer,
-    rpc_context::Provider, utils::catch_all,
+    address::parse_address,
+    constants::{CALIBNET_RATE_LIMIT_SECONDS, MAINNET_RATE_LIMIT_SECONDS},
+    lotus_json::LotusJson,
+    message::message_transfer,
+    rpc_context::Provider,
+    utils::catch_all,
 };
 
 use super::utils::faucet_address;
@@ -206,9 +210,12 @@ impl FaucetController {
                             }
                             Err(e) => {
                                 log::error!("Failed to sign message: {}", e);
-                                faucet
-                                    .send_limited
-                                    .set(crate::constants::RATE_LIMIT_SECONDS as i32);
+                                let rate_limit_seconds = if is_mainnet {
+                                    MAINNET_RATE_LIMIT_SECONDS
+                                } else {
+                                    CALIBNET_RATE_LIMIT_SECONDS
+                                };
+                                faucet.send_limited.set(rate_limit_seconds as i32);
                             }
                         }
                         Ok(())

--- a/src/faucet/utils.rs
+++ b/src/faucet/utils.rs
@@ -46,12 +46,17 @@ pub async fn sign_with_secret_key(
             .secret("RATE_LIMITER_DISABLED")
             .map(|v| v.to_string().to_lowercase() == "true")
             .unwrap_or(false);
-        let may_sign = rate_limiter_disabled || query_rate_limiter().await?;
-
+        let network = if is_mainnet { "mainnet" } else { "calibnet" };
+        let may_sign = rate_limiter_disabled || query_rate_limiter(network).await?;
+        let rate_limit_seconds = if is_mainnet {
+            crate::constants::MAINNET_RATE_LIMIT_SECONDS
+        } else {
+            crate::constants::CALIBNET_RATE_LIMIT_SECONDS
+        };
         if !may_sign {
             return Err(ServerFnError::ServerError(format!(
                 "Rate limit exceeded - wait {} seconds",
-                crate::constants::RATE_LIMIT_SECONDS
+                rate_limit_seconds
             )));
         }
 
@@ -96,7 +101,7 @@ pub async fn secret_key(network: Network) -> Result<Key, ServerFnError> {
 }
 
 #[cfg(feature = "ssr")]
-pub async fn query_rate_limiter() -> Result<bool, ServerFnError> {
+pub async fn query_rate_limiter(network: &str) -> Result<bool, ServerFnError> {
     use axum::Extension;
     use leptos_axum::extract;
     use std::sync::Arc;
@@ -105,10 +110,13 @@ pub async fn query_rate_limiter() -> Result<bool, ServerFnError> {
     let Extension(env): Extension<Arc<Env>> = extract().await?;
     let rate_limiter = env
         .durable_object("RATE_LIMITER")?
-        .id_from_name("RATE_LIMITER")?
+        .id_from_name(network)?
         .get_stub()?;
     Ok(rate_limiter
-        .fetch_with_request(Request::new("http://do/rate_limiter", Method::Get)?)
+        .fetch_with_request(Request::new(
+            &format!("http://do/rate_limiter/{}", network),
+            Method::Get,
+        )?)
         .await?
         .json::<bool>()
         .await?)

--- a/src/faucet/views.rs
+++ b/src/faucet/views.rs
@@ -243,7 +243,7 @@ pub fn Faucet_Calibnet() -> impl IntoView {
             <Faucet target_network=Network::Testnet />
         </div>
         <div class="text-center mt-4">
-            "This faucet distributes " { format_balance(&crate::constants::CALIBNET_DRIP_AMOUNT, crate::constants::FIL_CALIBNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
+            "This faucet distributes " { format_balance(&crate::constants::CALIBNET_DRIP_AMOUNT, crate::constants::FIL_CALIBNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::CALIBNET_RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
         </div>
     }
 }
@@ -264,7 +264,7 @@ pub fn Faucet_Mainnet() -> impl IntoView {
             <h1 class="text-4xl font-bold mb-6 text-center">Filecoin Mainnet Faucet</h1>
             <Faucet target_network=Network::Mainnet />
         <div class="text-center mt-4">
-            "This faucet distributes " { format_balance(&crate::constants::MAINNET_DRIP_AMOUNT, crate::constants::FIL_MAINNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans or service termination. Faucet funds are limited and may run out. They are replenished periodically."
+            "This faucet distributes " { format_balance(&crate::constants::MAINNET_DRIP_AMOUNT, crate::constants::FIL_MAINNET_UNIT) } " per request. It is rate-limited to 1 request per " {crate::constants::MAINNET_RATE_LIMIT_SECONDS} " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans or service termination. Faucet funds are limited and may run out. They are replenished periodically."
         </div>
         </div>
     }

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,59 +1,65 @@
+use crate::constants::{CALIBNET_RATE_LIMIT_SECONDS, MAINNET_RATE_LIMIT_SECONDS};
 use chrono::{DateTime, Duration, Utc};
 use worker::*;
 
 #[durable_object]
 pub struct RateLimiter {
     state: State,
-    #[allow(unused)]
-    block_until: DateTime<Utc>,
 }
 
 #[durable_object]
 impl DurableObject for RateLimiter {
     fn new(state: State, _env: Env) -> Self {
-        Self {
-            state,
-            block_until: Utc::now(),
-        }
+        Self { state }
     }
 
-    async fn fetch(&mut self, _req: Request) -> Result<Response> {
+    async fn fetch(&mut self, req: Request) -> Result<Response> {
         let now = Utc::now();
+        let path = req.path();
+        let (network, rate_limit_seconds) = if path.contains("mainnet") {
+            ("mainnet", MAINNET_RATE_LIMIT_SECONDS)
+        } else {
+            ("calibnet", CALIBNET_RATE_LIMIT_SECONDS)
+        };
+
         let block_until = self
             .state
             .storage()
             .get("block_until")
             .await
             .map(|v| DateTime::<Utc>::from_timestamp(v, 0).unwrap_or_default())
-            .unwrap_or(Utc::now());
+            .unwrap_or(now);
+
+        let is_allowed = block_until <= now;
+
         console_log!(
-            "Rate limiter invoked: now={:?}, block_until={:?}, may_sign={:?}",
+            "Rate limiter for {} invoked: now={:?}, block_until={:?}, may_sign={:?}",
+            network,
             now,
             block_until,
-            block_until <= now
+            is_allowed
         );
-        if block_until <= now {
+
+        if is_allowed {
             // This Durable Object will be deleted after the alarm is triggered
+            let next_block = now + Duration::seconds(rate_limit_seconds);
+            self.state
+                .storage()
+                .put("block_until", next_block.timestamp())
+                .await?;
             self.state
                 .storage()
                 .set_alarm(std::time::Duration::from_secs(
-                    crate::constants::RATE_LIMIT_SECONDS as u64 + 1,
+                    rate_limit_seconds as u64 + 1,
                 ))
                 .await?;
-            let block_until = now + Duration::seconds(crate::constants::RATE_LIMIT_SECONDS);
-            self.state
-                .storage()
-                .put("block_until", block_until.timestamp())
-                .await?;
-
-            Response::from_json(&true)
-        } else {
-            Response::from_json(&false)
         }
+        Response::from_json(&is_allowed)
     }
 
     async fn alarm(&mut self) -> Result<Response> {
         console_log!("Rate limiter alarm triggered. DurableObject will be deleted.");
+        self.state.storage().delete("block_until").await.ok();
         Response::ok("OK")
     }
 }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

Fixed:
1. Use `now` as default which is derived when fetch is triggered instead of calling `Utc::now` again when setting default for `block_until` as its used for comparison `block_until <= now`
2. Clear storage `state.storage().delete_all()` when durable object alarm is triggered.
3. Remove `block_until: DateTime<Utc>` field from `RateLimiter` as it's not used anymore. No migration required.

Tested manually for both `Calibnet` and `Mainnet`, no automated test yet

<img width="1502" alt="Screenshot 2025-04-16 at 12 49 08 PM" src="https://github.com/user-attachments/assets/b459dd78-c184-4f5c-809e-db033d320cdf" />

<img width="1502" alt="Screenshot 2025-04-16 at 12 49 55 PM" src="https://github.com/user-attachments/assets/9b11af56-7ab4-43e4-8322-3584edb900fb" />

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #137 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
