### PR TITLE
Add sitemap and robots page

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://forest-explorer.chainsafe.dev/sitemap.xml 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://forest-explorer.chainsafe.dev/</loc>
+        <lastmod>2024-04-30</lastmod>
+        <changefreq>daily</changefreq>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>https://forest-explorer.chainsafe.dev/faucet</loc>
+        <lastmod>2024-04-30</lastmod>
+        <changefreq>daily</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://forest-explorer.chainsafe.dev/faucet/calibnet</loc>
+        <lastmod>2024-04-30</lastmod>
+        <changefreq>daily</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://forest-explorer.chainsafe.dev/faucet/mainnet</loc>
+        <lastmod>2024-04-30</lastmod>
+        <changefreq>daily</changefreq>
+        <priority>0.8</priority>
+    </url>
+</urlset> 


### PR DESCRIPTION
## Summary of changes

[Forest Filecoin Explorer](https://forest-explorer.chainsafe.dev/) is currently missing a `robots.txt` file and an XML `sitemap`, both of which are important for effective search engine indexing and SEO.

Changes introduced in this pull request:
- added `robots.txt` file
- added `sitemap.xml` file

➡️ **One thing that needs to be done after PR is merged:**
- [ ] [Submit the sitemap to Google Search Console and Bing Webmaster Tools.](https://yoast.com/help/submit-sitemap-search-engines/). Explicit submission helps search engines prioritize important pages and crawl the site more efficiently. 


For additional context, please refer to the Filecoin Foundation UXIT [Filecoin Forest Explorer Faucet Report](https://filecoin.notion.site/Filecoin-Forest-Explorer-Faucet-Report-19d7631f2825802b8e53e53fe4cd747e).


## Other information and links
<img width="1053" alt="Screenshot 2025-04-30 at 16 30 05" src="https://github.com/user-attachments/assets/f3cb28ff-7727-4b47-bed9-bffb6085bd0f" />


## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [ ] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [ ] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [ ] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
