### PR TITLE
fix: axum 0.8 wildcards handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ mod ssr_imports {
                 let leptos_options = leptos_options.clone();
                 move || shell(leptos_options.clone())
             })
-            .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
+            .route("/api/{*fn_name}", post(leptos_axum::handle_server_fns))
             .with_state(leptos_options)
             .layer(Extension(Arc::new(env)));
         app


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

There is an issue with the newest axum update from https://github.com/ChainSafe/forest-explorer/pull/212

![image](https://github.com/user-attachments/assets/6c4c0760-8378-461f-8964-aca45dee2c73)


```
Path segments must not start with `*`.
For wildcard capture, use `{*wildcard}`.
If you meant to literally match a segment starting with an asterisk, call `without_v07_checks` on the router.
```

This PR resolves it as suggested by the error message. :) 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
