### PR TITLE
fix(ci): skip codecov upload for external PRs

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,14 +21,13 @@ jobs:
           fetch-depth: 2 # needed by codecov sometimes
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
-        env:
-          RUSTC_WRAPPER:
       - uses: actions/upload-artifact@v4
         with:
           name: lcov.info
           path: lcov.info
           if-no-files-found: error
       - name: Upload to codecov
+        if: env.CODECOV_TOKEN != ''
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

To unblock https://github.com/ChainSafe/forest-explorer/pull/211 because external PRs have no access to `vars` and `secrets`

Changes introduced in this pull request:

-

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
