### PR TITLE
chore: decouple the code from mainnet/calibnet reign

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tuple 1.1.0",
+ "strum",
  "tower",
  "tower-service",
  "url",
@@ -1291,6 +1292,12 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -3581,6 +3588,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "forest-explorer"
 version = "0.1.0"
 edition = "2021"
 authors = ["Forest Team <forest@chainsafe.io>"]
+description = "Serverless Filecoin Explorer with faucet capabilities"
+repository = "https://github.com/ChainSafe/forest-explorer"
+license = "Apache-2.0 OR MIT"
 
 [lib]
 crate-type = ["cdylib"]
@@ -37,6 +40,7 @@ send_wrapper = "0.6"
 serde = "1"
 serde_json = "1"
 serde_tuple = "1"
+strum = { version = "0.27.1", features = ["derive"] }
 tower = { version = "0.5", optional = true }
 tower-service = "0.3"
 url = { version = "2" }

--- a/src/faucet/constants.rs
+++ b/src/faucet/constants.rs
@@ -1,16 +1,108 @@
-use fvm_shared::econ::TokenAmount;
+use fvm_shared::{address::Network, econ::TokenAmount};
+use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
+use strum::EnumString;
 
-// Calibnet constants
-pub const CALIBNET_RATE_LIMIT_SECONDS: i64 = 60;
-pub static FIL_CALIBNET_UNIT: &str = "tFIL";
 /// The amount of mainnet FIL to be dripped to the user. This corresponds to 1 tFIL.
-pub static CALIBNET_DRIP_AMOUNT: LazyLock<TokenAmount> =
+static CALIBNET_DRIP_AMOUNT: LazyLock<TokenAmount> = LazyLock::new(|| TokenAmount::from_whole(1));
+
+/// The amount of mainnet FIL to be dripped to the user. This corresponds to 0.01 FIL.
+static MAINNET_DRIP_AMOUNT: LazyLock<TokenAmount> =
+    LazyLock::new(|| TokenAmount::from_nano(10_000_000));
+
+/// The amount of calibnet `USDFC` to be dripped to the user. This corresponds to 1 `tUSDFC`.
+static CALIBNET_USDFC_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_whole(1));
 
-// Mainnet constants
-pub const MAINNET_RATE_LIMIT_SECONDS: i64 = 600;
-pub static FIL_MAINNET_UNIT: &str = "FIL";
-/// The amount of mainnet FIL to be dripped to the user. This corresponds to 0.01 FIL.
-pub static MAINNET_DRIP_AMOUNT: LazyLock<TokenAmount> =
-    LazyLock::new(|| TokenAmount::from_nano(10_000_000));
+#[derive(strum::Display, EnumString, Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub enum FaucetInfo {
+    MainnetFIL,
+    CalibnetFIL,
+    CalibnetUSDFC,
+}
+
+impl FaucetInfo {
+    /// Return the drip amount for the given faucet in the defined token unit.
+    pub fn drip_amount(&self) -> &TokenAmount {
+        match self {
+            FaucetInfo::MainnetFIL => &MAINNET_DRIP_AMOUNT,
+            FaucetInfo::CalibnetFIL => &CALIBNET_DRIP_AMOUNT,
+            FaucetInfo::CalibnetUSDFC => &CALIBNET_USDFC_DRIP_AMOUNT,
+        }
+    }
+
+    /// Returns the rate limit in seconds for the given faucet. The rate limit defines period after
+    /// which the faucet is temporarily disabled and no more drips can be sent.
+    pub fn rate_limit_seconds(&self) -> i64 {
+        match self {
+            FaucetInfo::MainnetFIL => 600,
+            FaucetInfo::CalibnetFIL => 60,
+            FaucetInfo::CalibnetUSDFC => 60,
+        }
+    }
+
+    /// Returns the unit of the token for the given faucet.
+    pub fn unit(&self) -> &str {
+        match self {
+            FaucetInfo::MainnetFIL => "FIL",
+            FaucetInfo::CalibnetFIL => "tFIL",
+            FaucetInfo::CalibnetUSDFC => "tUSDFC",
+        }
+    }
+
+    /// Returns the the secret key label as configured in the CloudFlare Worker secrets.
+    #[cfg(any(test, feature = "ssr"))]
+    pub fn secret_key_name(&self) -> &str {
+        match self {
+            FaucetInfo::CalibnetFIL => "SECRET_WALLET",
+            FaucetInfo::MainnetFIL => "SECRET_MAINNET_WALLET",
+            FaucetInfo::CalibnetUSDFC => "SECRET_CALIBNET_USDFC_WALLET",
+        }
+    }
+
+    /// Returns the network type for the given faucet. Note that there might be multiple faucets on
+    /// a given network, e.g., for ERC-20 tokens.
+    pub fn network(&self) -> Network {
+        match self {
+            FaucetInfo::MainnetFIL => Network::Mainnet,
+            FaucetInfo::CalibnetFIL | FaucetInfo::CalibnetUSDFC => Network::Testnet,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_faucet_info() {
+        // these tests are not exactly useful, but they give coverage and ensure that some warts with
+        // lazily initializing constants are caught.
+        let mainnet_faucet = FaucetInfo::MainnetFIL;
+        assert_eq!(mainnet_faucet.drip_amount(), &*MAINNET_DRIP_AMOUNT);
+        assert_eq!(mainnet_faucet.rate_limit_seconds(), 600);
+        assert_eq!(mainnet_faucet.unit(), "FIL");
+        assert_eq!(mainnet_faucet.network(), Network::Mainnet);
+        assert_eq!(mainnet_faucet.secret_key_name(), "SECRET_MAINNET_WALLET");
+
+        let calibnet_fil_faucet = FaucetInfo::CalibnetFIL;
+        assert_eq!(calibnet_fil_faucet.drip_amount(), &*CALIBNET_DRIP_AMOUNT);
+        assert_eq!(calibnet_fil_faucet.rate_limit_seconds(), 60);
+        assert_eq!(calibnet_fil_faucet.unit(), "tFIL");
+        assert_eq!(calibnet_fil_faucet.network(), Network::Testnet);
+        assert_eq!(calibnet_fil_faucet.secret_key_name(), "SECRET_WALLET");
+
+        let calibnet_usdfc_faucet = FaucetInfo::CalibnetUSDFC;
+        assert_eq!(
+            calibnet_usdfc_faucet.drip_amount(),
+            &*CALIBNET_USDFC_DRIP_AMOUNT
+        );
+        assert_eq!(calibnet_usdfc_faucet.rate_limit_seconds(), 60);
+        assert_eq!(calibnet_usdfc_faucet.unit(), "tUSDFC");
+        assert_eq!(calibnet_usdfc_faucet.network(), Network::Testnet);
+        assert_eq!(
+            calibnet_usdfc_faucet.secret_key_name(),
+            "SECRET_CALIBNET_USDFC_WALLET"
+        );
+    }
+}

--- a/src/faucet/model.rs
+++ b/src/faucet/model.rs
@@ -1,11 +1,10 @@
 use cid::Cid;
-use fvm_shared::{address::Network, econ::TokenAmount};
+use fvm_shared::econ::TokenAmount;
 use leptos::prelude::*;
 use uuid::Uuid;
 
 #[derive(Clone)]
 pub(super) struct FaucetModel {
-    pub network: Network,
     pub send_disabled: RwSignal<bool>,
     pub send_limited: RwSignal<i32>,
     pub sent_messages: RwSignal<Vec<(Cid, bool)>>,

--- a/src/faucet/server.rs
+++ b/src/faucet/server.rs
@@ -2,37 +2,29 @@
 use crate::utils::key::{sign, Key};
 use crate::utils::lotus_json::{signed_message::SignedMessage, LotusJson};
 use anyhow::Result;
-#[cfg(feature = "ssr")]
-use fvm_shared::address::Network;
 use fvm_shared::{address::Address, message::Message};
 use leptos::{prelude::ServerFnError, server};
 
+use super::constants::FaucetInfo;
+
 #[server]
-pub async fn faucet_address(is_mainnet: bool) -> Result<LotusJson<Address>, ServerFnError> {
-    let network = if is_mainnet {
-        Network::Mainnet
-    } else {
-        Network::Testnet
-    };
-    let key = secret_key(network).await?;
+pub async fn faucet_address(faucet_info: FaucetInfo) -> Result<LotusJson<Address>, ServerFnError> {
+    let key = secret_key(faucet_info).await?;
     Ok(LotusJson(key.address))
 }
 
 #[server]
 pub async fn sign_with_secret_key(
     msg: LotusJson<Message>,
-    is_mainnet: bool,
+    faucet_info: FaucetInfo,
 ) -> Result<LotusJson<SignedMessage>, ServerFnError> {
     use crate::utils::lotus_json::signed_message::message_cid;
     use leptos::server_fn::error;
     use send_wrapper::SendWrapper;
     let LotusJson(msg) = msg;
     let cid = message_cid(&msg);
-    let amount_limit = match is_mainnet {
-        true => crate::faucet::constants::MAINNET_DRIP_AMOUNT.clone(),
-        false => crate::faucet::constants::CALIBNET_DRIP_AMOUNT.clone(),
-    };
-    if msg.value > amount_limit {
+    let amount_limit = faucet_info.drip_amount();
+    if &msg.value > amount_limit {
         return Err(ServerFnError::ServerError(
             "Amount limit exceeded".to_string(),
         ));
@@ -47,26 +39,15 @@ pub async fn sign_with_secret_key(
             .secret("RATE_LIMITER_DISABLED")
             .map(|v| v.to_string().to_lowercase() == "true")
             .unwrap_or(false);
-        let network = if is_mainnet { "mainnet" } else { "calibnet" };
-        let may_sign = rate_limiter_disabled || query_rate_limiter(network).await?;
-        let rate_limit_seconds = if is_mainnet {
-            crate::faucet::constants::MAINNET_RATE_LIMIT_SECONDS
-        } else {
-            crate::faucet::constants::CALIBNET_RATE_LIMIT_SECONDS
-        };
+        let may_sign = rate_limiter_disabled || query_rate_limiter(faucet_info).await?;
+        let rate_limit_seconds = faucet_info.rate_limit_seconds();
         if !may_sign {
             return Err(ServerFnError::ServerError(format!(
-                "Rate limit exceeded - wait {} seconds",
-                rate_limit_seconds
+                "Rate limit exceeded - wait {rate_limit_seconds} seconds"
             )));
         }
 
-        let network = if is_mainnet {
-            Network::Mainnet
-        } else {
-            Network::Testnet
-        };
-        let key = secret_key(network).await?;
+        let key = secret_key(faucet_info).await?;
         #[allow(deprecated)]
         let sig = sign(
             key.key_info.r#type,
@@ -83,7 +64,7 @@ pub async fn sign_with_secret_key(
 }
 
 #[cfg(feature = "ssr")]
-pub async fn secret_key(network: Network) -> Result<Key, ServerFnError> {
+pub async fn secret_key(faucet_info: FaucetInfo) -> Result<Key, ServerFnError> {
     use crate::utils::key::KeyInfo;
     use axum::Extension;
     use leptos::server_fn::error;
@@ -91,20 +72,15 @@ pub async fn secret_key(network: Network) -> Result<Key, ServerFnError> {
     use std::{str::FromStr as _, sync::Arc};
     use worker::Env;
 
-    let secret_key_name = match network {
-        Network::Testnet => "SECRET_WALLET",
-        Network::Mainnet => "SECRET_MAINNET_WALLET",
-    };
-
     let Extension(env): Extension<Arc<Env>> = extract().await?;
     #[allow(deprecated)]
-    let key_info = KeyInfo::from_str(&env.secret(secret_key_name)?.to_string())
+    let key_info = KeyInfo::from_str(&env.secret(faucet_info.secret_key_name())?.to_string())
         .map_err(|e| ServerFnError::<error::NoCustomError>::ServerError(e.to_string()))?;
     Key::try_from(key_info).map_err(|e| ServerFnError::ServerError(e.to_string()))
 }
 
 #[cfg(feature = "ssr")]
-pub async fn query_rate_limiter(network: &str) -> Result<bool, ServerFnError> {
+pub async fn query_rate_limiter(faucet_info: FaucetInfo) -> Result<bool, ServerFnError> {
     use axum::Extension;
     use leptos_axum::extract;
     use std::sync::Arc;
@@ -113,11 +89,11 @@ pub async fn query_rate_limiter(network: &str) -> Result<bool, ServerFnError> {
     let Extension(env): Extension<Arc<Env>> = extract().await?;
     let rate_limiter = env
         .durable_object("RATE_LIMITER")?
-        .id_from_name(network)?
+        .id_from_name(&faucet_info.to_string())?
         .get_stub()?;
     Ok(rate_limiter
         .fetch_with_request(Request::new(
-            &format!("http://do/rate_limiter/{}", network),
+            &format!("http://do/rate_limiter/{faucet_info}"),
             Method::Get,
         )?)
         .await?

--- a/src/faucet/views/faucets/calibnet.rs
+++ b/src/faucet/views/faucets/calibnet.rs
@@ -1,7 +1,5 @@
 use super::Faucet;
-use crate::faucet::constants::{
-    CALIBNET_DRIP_AMOUNT, CALIBNET_RATE_LIMIT_SECONDS, FIL_CALIBNET_UNIT,
-};
+use crate::faucet::constants::FaucetInfo;
 use crate::utils::format::format_balance;
 use crate::utils::rpc_context::{Provider, RpcContext};
 use fvm_shared::address::Network;
@@ -11,6 +9,9 @@ use leptos_meta::{Meta, Title};
 
 #[component]
 pub fn Faucet_Calibnet() -> impl IntoView {
+    let drip_amount = FaucetInfo::CalibnetFIL.drip_amount();
+    let token_unit = FaucetInfo::CalibnetFIL.unit();
+    let rate_limit_seconds = FaucetInfo::CalibnetFIL.rate_limit_seconds();
     let rpc_context = RpcContext::use_context();
     // Set rpc context to calibnet url
     rpc_context.set(Provider::get_network_url(Network::Testnet));
@@ -23,11 +24,11 @@ pub fn Faucet_Calibnet() -> impl IntoView {
         />
         <div>
             <h1 class="header">Filecoin Calibnet Faucet</h1>
-            <Faucet target_network=Network::Testnet />
+            <Faucet faucet_info=FaucetInfo::CalibnetFIL />
         </div>
         <div class="description">
-            "This faucet distributes " {format_balance(&CALIBNET_DRIP_AMOUNT, FIL_CALIBNET_UNIT)}
-            " per request. It is rate-limited to 1 request per " {CALIBNET_RATE_LIMIT_SECONDS}
+            "This faucet distributes " {format_balance(drip_amount, token_unit)}
+            " per request. It is rate-limited to 1 request per " {rate_limit_seconds}
             " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
         </div>
     }

--- a/src/faucet/views/faucets/mainnet.rs
+++ b/src/faucet/views/faucets/mainnet.rs
@@ -1,5 +1,5 @@
 use super::Faucet;
-use crate::faucet::constants::{FIL_MAINNET_UNIT, MAINNET_DRIP_AMOUNT, MAINNET_RATE_LIMIT_SECONDS};
+use crate::faucet::constants::FaucetInfo;
 use crate::utils::format::format_balance;
 use crate::utils::rpc_context::{Provider, RpcContext};
 use fvm_shared::address::Network;
@@ -9,6 +9,9 @@ use leptos_meta::{Meta, Title};
 
 #[component]
 pub fn Faucet_Mainnet() -> impl IntoView {
+    let drip_amount = FaucetInfo::MainnetFIL.drip_amount();
+    let token_unit = FaucetInfo::MainnetFIL.unit();
+    let rate_limit_seconds = FaucetInfo::MainnetFIL.rate_limit_seconds();
     let rpc_context = RpcContext::use_context();
     // Set rpc context to mainnet url
     rpc_context.set(Provider::get_network_url(Network::Mainnet));
@@ -18,10 +21,10 @@ pub fn Faucet_Mainnet() -> impl IntoView {
         <Meta name="description" content="Filecoin Mainnet Faucet dispensing tokens for testing purposes." />
         <div>
             <h1 class="header">Filecoin Mainnet Faucet</h1>
-            <Faucet target_network=Network::Mainnet />
+            <Faucet faucet_info=FaucetInfo::MainnetFIL />
             <div class="description">
-                "This faucet distributes " {format_balance(&MAINNET_DRIP_AMOUNT, FIL_MAINNET_UNIT)}
-                " per request. It is rate-limited to 1 request per " {MAINNET_RATE_LIMIT_SECONDS}
+                "This faucet distributes " {format_balance(drip_amount, token_unit)}
+                " per request. It is rate-limited to 1 request per " {rate_limit_seconds}
                 " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans or service termination. Faucet funds are limited and may run out. They are replenished periodically."
             </div>
         </div>

--- a/src/faucet/views/faucets/mod.rs
+++ b/src/faucet/views/faucets/mod.rs
@@ -7,6 +7,7 @@ use leptos::{component, leptos_dom::helpers::event_target_value, view, IntoView}
 use leptos_meta::{Meta, Title};
 use url::Url;
 
+use crate::faucet::constants::FaucetInfo;
 use crate::faucet::controller::FaucetController;
 use crate::faucet::views::components::alert::ErrorMessages;
 use crate::faucet::views::components::balance::{FaucetBalance, TargetBalance};
@@ -107,13 +108,15 @@ fn use_faucet_polling(faucet: RwSignal<FaucetController>) {
 }
 
 #[component]
-pub fn Faucet(target_network: Network) -> impl IntoView {
-    let faucet = RwSignal::new(FaucetController::new(target_network));
+pub fn Faucet(faucet_info: FaucetInfo) -> impl IntoView {
+    let faucet = RwSignal::new(FaucetController::new(faucet_info));
 
     #[cfg(feature = "hydrate")]
     {
         use_faucet_polling(faucet);
     }
+
+    let target_network = faucet_info.network();
 
     let faucet_tx_base_url = match target_network {
         Network::Mainnet => {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- make the faucets more configurable by supplying faucet configuration instead of a ambiguous answer to a question whether it's mainnet. The former approach won't work for additional networks or ERC-20 tokens faucet on existing networks.
- cleanups in durable object paths,
- this doesn't change (or at least shouldn't!) anything functionally.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
