### PR TITLE
Fix incorrect transaction link

### DIFF
--- a/src/faucet/views/faucets/mod.rs
+++ b/src/faucet/views/faucets/mod.rs
@@ -13,6 +13,7 @@ use crate::faucet::views::components::alert::ErrorMessages;
 use crate::faucet::views::components::balance::{FaucetBalance, TargetBalance};
 use crate::faucet::views::components::nav::{GotoFaucetList, GotoHome};
 use crate::faucet::views::components::transaction::{TransactionHistoryButton, TransactionList};
+use crate::utils::address::is_valid_prefix;
 
 #[component]
 fn FaucetInput(faucet: RwSignal<FaucetController>) -> impl IntoView {
@@ -153,7 +154,11 @@ pub fn Faucet(faucet_info: FaucetInfo) -> impl IntoView {
             }}
         </div>
         <div class="nav-container">
-            <TransactionHistoryButton faucet=faucet faucet_tx_base_url=faucet_tx_base_url />
+            <Show
+                when=move || is_valid_prefix(&faucet.get().get_sender_address(), target_network)
+            >
+                <TransactionHistoryButton faucet=faucet faucet_tx_base_url=faucet_tx_base_url />
+            </Show>
             <GotoFaucetList />
         </div>
     }

--- a/src/faucet/views/faucets/mod.rs
+++ b/src/faucet/views/faucets/mod.rs
@@ -154,9 +154,7 @@ pub fn Faucet(faucet_info: FaucetInfo) -> impl IntoView {
             }}
         </div>
         <div class="nav-container">
-            <Show
-                when=move || is_valid_prefix(&faucet.get().get_sender_address(), target_network)
-            >
+            <Show when=move || is_valid_prefix(&faucet.get().get_sender_address(), target_network)>
                 <TransactionHistoryButton faucet=faucet faucet_tx_base_url=faucet_tx_base_url />
             </Show>
             <GotoFaucetList />

--- a/src/utils/address.rs
+++ b/src/utils/address.rs
@@ -6,7 +6,7 @@ use fvm_shared::ActorID;
 const ETH_ADDRESS_LENGTH: usize = 42;
 const EAM_NAMESPACE: ActorID = 10;
 
-fn is_valid_prefix(s: &str, n: Network) -> bool {
+pub fn is_valid_prefix(s: &str, n: Network) -> bool {
     if s.len() < 2 {
         return false;
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `RpcContext` takes time to update when the network changes, the `Transaction History` button is now rendered only after the `RpcContext` has been updated correctly.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #235 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
