### PR TITLE
fix: wait for network idle in e2e

### DIFF
--- a/e2e/script.js
+++ b/e2e/script.js
@@ -21,7 +21,7 @@ const BASE_URL = "http://127.0.0.1:8787";
 
 // Check if the path is reachable
 async function checkPath(page, path) {
-  const res = await page.goto(`${BASE_URL}${path}`, { timeout: 60_000 });
+  const res = await page.goto(`${BASE_URL}${path}`, { timeout: 60_000, waitUntil: "networkidle" });
   check(res, { [`GET ${path} → 200`]: (r) => r && r.status() === 200 });
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- This might not be the best way to fix e2e flakiness, especially if we introduce more network events to the faucet, but it resolves the e2e flakiness that we experience at the moment. A better solution might come as a follow-up.

https://grafana.com/docs/k6/latest/javascript-api/k6-browser/page/waitfornavigation/#events

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
