### PR TITLE
fix: bake env URLs to e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,10 +20,6 @@ env:
   RUSTC_WRAPPER: sccache
   CC: sccache clang
   CXX: sccache clang++
-  FAUCET_TOPUP_REQ_URL: '${{ vars.FAUCET_TOPUP_REQ_URL }}'
-  FAUCET_TX_URL_CALIBNET: '${{ vars.FAUCET_TX_URL_CALIBNET }}'
-  FAUCET_TX_URL_MAINNET: '${{ vars.FAUCET_TX_URL_MAINNET }}'
-
 jobs:
   e2e:
     runs-on: ubuntu-latest
@@ -64,6 +60,14 @@ jobs:
 
       - name: Run website
         run: |
+          # These might or might not be the same as used for deployment. They are used strictly for testing purposes.
+          # Note: those can't be put directly as environment variables in GH Actions (without a default value) due to
+          # the way GH Actions handles secrets and variables; forks would not be able to access them and in turn
+          # would not be able to run the E2E tests.
+          export FAUCET_TOPUP_REQ_URL="https://github.com/ChainSafe/forest-explorer/discussions/134"
+          export FAUCET_TX_URL_CALIBNET="https://beryx.io/fil/calibration/"
+          export FAUCET_TX_URL_MAINNET="https://beryx.io/fil/mainnet/"
+
           corepack enable
           yarn --immutable
           yarn build


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Env variables can't be read from forks, which makes fork PRs fail on e2e. See https://github.com/orgs/community/discussions/44322 

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
