### PR TITLE
Fix: Make `SignWithSecretKey` less risky

### DIFF
--- a/src/faucet/controller.rs
+++ b/src/faucet/controller.rs
@@ -228,9 +228,7 @@ impl FaucetController {
                         let raw_msg = message_transfer(from, addr, info.drip_amount().clone());
                         let msg = rpc.estimate_gas(raw_msg).await?;
                         match signed_fil_transfer(
-                            LotusJson(from),
                             LotusJson(addr),
-                            LotusJson(msg.value),
                             msg.gas_limit,
                             LotusJson(msg.gas_fee_cap),
                             LotusJson(msg.gas_premium),

--- a/src/faucet/controller.rs
+++ b/src/faucet/controller.rs
@@ -1,5 +1,5 @@
 use super::constants::{FaucetInfo, TokenType};
-use super::server_api::{faucet_address, sign_with_secret_key, signed_erc20_transfer};
+use super::server_api::{faucet_address, signed_erc20_transfer, signed_fil_transfer};
 use crate::faucet::model::FaucetModel;
 use crate::utils::address::AddressAlloyExt;
 use crate::utils::lotus_json::LotusJson;
@@ -217,27 +217,26 @@ impl FaucetController {
             Ok(addr) => {
                 spawn_local(async move {
                     catch_all(faucet.error_messages, async move {
+                        faucet.send_disabled.set(true);
+
                         let rpc = Provider::from_network(network);
                         let from = faucet_address(info)
                             .await
                             .map_err(|e| anyhow::anyhow!("Error getting faucet address: {}", e))?
                             .to_filecoin_address(network)?;
-
-                        faucet.send_disabled.set(true);
                         let nonce = rpc.mpool_get_nonce(from).await?;
-                        let mut msg = message_transfer(from, addr, info.drip_amount().clone());
-                        msg.sequence = nonce;
-                        let msg = rpc.estimate_gas(msg).await?;
-                        match sign_with_secret_key(LotusJson(msg.clone()), info).await {
-                            Ok(LotusJson(smsg)) => {
-                                let cid = rpc.mpool_push(smsg).await?;
+                        let raw_msg = message_transfer(from, addr, info.drip_amount().clone());
+                        let msg = rpc.estimate_gas(raw_msg).await?;
+                        match signed_fil_transfer(LotusJson(msg), nonce, info).await {
+                            Ok(LotusJson(signed)) => {
+                                let cid = rpc.mpool_push(signed).await?;
                                 faucet.sent_messages.update(|messages| {
                                     messages.push((TransactionId::Native(cid), false));
                                 });
                                 log::info!("Sent message: {:?}", cid);
                             }
                             Err(e) => {
-                                log::error!("Failed to sign message: {}", e);
+                                console_log(&format!("Failed to sign message: {e}"));
                                 let rate_limit_seconds = info.rate_limit_seconds();
                                 faucet.send_limited.set(rate_limit_seconds as i32);
                             }

--- a/src/faucet/controller.rs
+++ b/src/faucet/controller.rs
@@ -227,7 +227,18 @@ impl FaucetController {
                         let nonce = rpc.mpool_get_nonce(from).await?;
                         let raw_msg = message_transfer(from, addr, info.drip_amount().clone());
                         let msg = rpc.estimate_gas(raw_msg).await?;
-                        match signed_fil_transfer(LotusJson(msg), nonce, info).await {
+                        match signed_fil_transfer(
+                            LotusJson(from),
+                            LotusJson(addr),
+                            LotusJson(msg.value),
+                            msg.gas_limit,
+                            LotusJson(msg.gas_fee_cap),
+                            LotusJson(msg.gas_premium),
+                            nonce,
+                            info,
+                        )
+                        .await
+                        {
                             Ok(LotusJson(signed)) => {
                                 let cid = rpc.mpool_push(signed).await?;
                                 faucet.sent_messages.update(|messages| {

--- a/src/faucet/server.rs
+++ b/src/faucet/server.rs
@@ -44,6 +44,10 @@ pub async fn secret_key(faucet_info: FaucetInfo) -> Result<Key, ServerFnError> {
     Key::try_from(key_info).map_err(ServerFnError::new)
 }
 
+/// Signs a message using the faucet's secret key.
+/// Note: it is important to ensure that the `Message` is fully controlled by the server
+/// not exposed to the client, as it might be modified by the client, leading to potential
+/// security issues.
 pub async fn sign_with_secret_key(
     msg: Message,
     faucet_info: FaucetInfo,

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -95,7 +95,7 @@ pub async fn signed_fil_transfer(
     sequence: u64,
     faucet_info: FaucetInfo,
 ) -> Result<LotusJson<SignedMessage>, ServerFnError> {
-    use crate::utils::message::message_transfer_custom;
+    use crate::utils::message::message_transfer_native;
     let LotusJson(to) = to;
     let LotusJson(gas_fee_cap) = gas_fee_cap;
     let LotusJson(gas_premium) = gas_premium;
@@ -105,7 +105,7 @@ pub async fn signed_fil_transfer(
         .to_filecoin_address(faucet_info.network())
         .map_err(ServerFnError::new)?;
 
-    let unsigned_msg = message_transfer_custom(
+    let unsigned_msg = message_transfer_native(
         from,
         to,
         faucet_info.drip_amount().clone(),

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -80,6 +80,12 @@ async fn faucet_eth_address(
     Ok(pk_addr)
 }
 
+/// Signs a Filecoin transfer message to the specified recipient with the given parameters.
+/// The required params are needed so that the server doesn't have to call the provider.
+/// Note: it's important that the message is constructed server-side to avoid exposing the
+/// `message` to the client, which could lead to security issues if the client were to
+/// manipulate the message data.
+/// This function is used for native Filecoin token transfers.
 #[server]
 pub async fn signed_fil_transfer(
     to: LotusJson<Address>,

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -95,7 +95,7 @@ pub async fn signed_fil_transfer(
     sequence: u64,
     faucet_info: FaucetInfo,
 ) -> Result<LotusJson<SignedMessage>, ServerFnError> {
-    use crate::utils::message::create_message;
+    use crate::utils::message::message_transfer_custom;
     let LotusJson(to) = to;
     let LotusJson(gas_fee_cap) = gas_fee_cap;
     let LotusJson(gas_premium) = gas_premium;
@@ -105,7 +105,7 @@ pub async fn signed_fil_transfer(
         .to_filecoin_address(faucet_info.network())
         .map_err(ServerFnError::new)?;
 
-    let unsigned_msg = create_message(
+    let unsigned_msg = message_transfer_custom(
         from,
         to,
         faucet_info.drip_amount().clone(),

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -81,6 +81,7 @@ async fn faucet_eth_address(
 }
 
 #[server]
+#[allow(clippy::too_many_arguments)]
 pub async fn signed_fil_transfer(
     from: LotusJson<Address>,
     to: LotusJson<Address>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ mod ssr_imports {
 
     #[event(start)]
     fn register() {
-        server_fn::axum::register_explicit::<faucet::server_api::SignWithSecretKey>();
+        server_fn::axum::register_explicit::<faucet::server_api::SignedFilTransfer>();
         server_fn::axum::register_explicit::<faucet::server_api::SignedErc20Transfer>();
         server_fn::axum::register_explicit::<faucet::server_api::FaucetAddress>();
     }

--- a/src/utils/message.rs
+++ b/src/utils/message.rs
@@ -3,16 +3,36 @@ use fvm_shared::message::Message;
 use fvm_shared::{address::Address, econ::TokenAmount, METHOD_SEND};
 
 pub fn message_transfer(from: Address, to: Address, value: TokenAmount) -> Message {
+    create_message(
+        from,
+        to,
+        value,
+        0,
+        TokenAmount::from_atto(0),
+        TokenAmount::from_atto(0),
+        0,
+    )
+}
+
+pub fn create_message(
+    from: Address,
+    to: Address,
+    value: TokenAmount,
+    gas_limit: u64,
+    gas_fee_cap: TokenAmount,
+    gas_premium: TokenAmount,
+    sequence: u64,
+) -> Message {
     Message {
         from,
         to,
         value,
         method_num: METHOD_SEND,
         params: RawBytes::new(vec![]),
-        gas_limit: 0,
-        gas_fee_cap: TokenAmount::from_atto(0),
-        gas_premium: TokenAmount::from_atto(0),
+        gas_limit,
+        gas_fee_cap,
+        gas_premium,
         version: 0,
-        sequence: 0,
+        sequence,
     }
 }

--- a/src/utils/message.rs
+++ b/src/utils/message.rs
@@ -4,7 +4,7 @@ use fvm_shared::{address::Address, econ::TokenAmount, METHOD_SEND};
 
 /// Creates a new transfer message with default values for gas and sequence.
 pub fn message_transfer(from: Address, to: Address, value: TokenAmount) -> Message {
-    message_transfer_custom(
+    message_transfer_native(
         from,
         to,
         value,
@@ -16,7 +16,7 @@ pub fn message_transfer(from: Address, to: Address, value: TokenAmount) -> Messa
 }
 
 /// Creates a new transfer message with specified values for gas and sequence.
-pub fn message_transfer_custom(
+pub fn message_transfer_native(
     from: Address,
     to: Address,
     value: TokenAmount,

--- a/src/utils/message.rs
+++ b/src/utils/message.rs
@@ -2,8 +2,9 @@ use fvm_ipld_encoding::RawBytes;
 use fvm_shared::message::Message;
 use fvm_shared::{address::Address, econ::TokenAmount, METHOD_SEND};
 
+/// Creates a new transfer message with default values for gas and sequence.
 pub fn message_transfer(from: Address, to: Address, value: TokenAmount) -> Message {
-    create_message(
+    message_transfer_custom(
         from,
         to,
         value,
@@ -14,7 +15,8 @@ pub fn message_transfer(from: Address, to: Address, value: TokenAmount) -> Messa
     )
 }
 
-pub fn create_message(
+/// Creates a new transfer message with specified values for gas and sequence.
+pub fn message_transfer_custom(
     from: Address,
     to: Address,
     value: TokenAmount,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Introduce `signed_fil_transfer` which signs a message with the given `nonce`.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #250 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
