### PR TITLE
Add wallet capping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,11 @@
 - [#199](https://github.com/ChainSafe/forest-explorer/pull/199) Added faucet
   transaction history button which is configurable using github env var.
 
-- [#137] (https://github.com/ChainSafe/forest-explorer/issues/137) Different
-  rate limitter for calibnet and mainnet
+- [#137](https://github.com/ChainSafe/forest-explorer/issues/137) Different rate
+  limiter for calibnet and mainnet
+
+- [#257](https://github.com/ChainSafe/forest-explorer/issues/257) Added per
+  wallet daily cap on token claim.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,6 +1923,7 @@ dependencies = [
  "serde_json",
  "serde_tuple 1.1.1",
  "strum",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tower-service",
@@ -4732,15 +4733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5124,9 +5116,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "any_spawner"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1891,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
+ "async-trait",
  "axum",
  "base64",
  "blake2b_simd",
@@ -1900,6 +1913,7 @@ dependencies = [
  "leptos_router",
  "libsecp256k1",
  "log",
+ "mockall",
  "multihash-codetable",
  "num-traits",
  "reqwest",
@@ -1909,6 +1923,7 @@ dependencies = [
  "serde_json",
  "serde_tuple 1.1.0",
  "strum",
+ "tokio",
  "tower",
  "tower-service",
  "url",
@@ -1926,6 +1941,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "funty"
@@ -3179,6 +3200,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +3667,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -4658,6 +4732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4918,6 +5001,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5035,7 +5124,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde = "1"
 serde_json = "1"
 serde_tuple = "1"
 strum = { version = "0.27.1", features = ["derive"] }
+thiserror = "1"
 tower = { version = "0.5", optional = true }
 tower-service = "0.3"
 url = { version = "2" }
@@ -55,7 +56,7 @@ worker-macros = { version = "0.6", features = ['http'], optional = true }
 [dev-dependencies]
 mockall = "0.12"
 rusty-fork = "0.3"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [features]
 hydrate = ["leptos/hydrate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 alloy = "1"
 anyhow = "1"
+async-trait = "0.1"
 axum = { version = "0.8", default-features = false, optional = true }
 base64 = "0.22"
 blake2b_simd = "1"
@@ -52,7 +53,9 @@ worker = { version = "0.6", features = ['http', 'axum'], optional = true }
 worker-macros = { version = "0.6", features = ['http'], optional = true }
 
 [dev-dependencies]
+mockall = "0.12"
 rusty-fork = "0.3"
+tokio = { version = "1", features = ["full"] }
 
 [features]
 hydrate = ["leptos/hydrate"]

--- a/src/faucet/constants.rs
+++ b/src/faucet/constants.rs
@@ -16,9 +16,9 @@ static CALIBNET_USDFC_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_whole(5));
 
 /// The multiplier applied to the number of tokens dripped per wallet every `wallet_limit_seconds`.
-/// This corresponds to 2x of drip amount
+/// This corresponds to 2 times of drip amount
 const MAINNET_WALLET_CAP_MULTIPLIER: i64 = 2;
-/// This corresponds to 5x of drip amount
+/// This corresponds to 5 times of drip amount
 const CALIBNET_WALLET_CAP_MULTIPLIER: i64 = 5;
 
 pub type ContractAddress = alloy::primitives::Address;

--- a/src/faucet/constants.rs
+++ b/src/faucet/constants.rs
@@ -16,20 +16,20 @@ static CALIBNET_USDFC_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_whole(5));
 
 /// Multiplier to determine the maximum amount of tokens that can be dripped per wallet every [`FaucetInfo::reset_limiter_seconds`].
-/// This corresponds to 1 × [`FaucetInfo::drip_amount`]
+/// This corresponds to 1 * [`FaucetInfo::drip_amount`]
 const MAINNET_PER_WALLET_DRIP_MULTIPLIER: i64 = 1;
-/// This corresponds to 2 × [`FaucetInfo::drip_amount`]
+/// This corresponds to 2 * [`FaucetInfo::drip_amount`]
 const CALIBNET_PER_WALLET_DRIP_MULTIPLIER: i64 = 2;
 
 /// Multiplier used to determine the maximum amount of tokens that can be dripped globally every [`FaucetInfo::reset_limiter_seconds`].
-/// This corresponds to 2 × [`FaucetInfo::drip_amount`]
+/// This corresponds to 2 * [`FaucetInfo::drip_amount`]
 const MAINNET_GLOBAL_DRIP_MULTIPLIER: i64 = 2;
-/// This corresponds to 5 × [`FaucetInfo::drip_amount`]
+/// This corresponds to 5 * [`FaucetInfo::drip_amount`]
 const CALIBNET_GLOBAL_DRIP_MULTIPLIER: i64 = 5;
 
-/// Cooldown duration in seconds between faucet requests on mainnet.
+/// Cool-down duration in seconds between faucet requests on mainnet.
 const MAINNET_COOLDOWN_SECONDS: i64 = 600; // 10 minutes
-/// Cooldown duration in seconds between faucet requests on calibnet.
+/// Cool-down duration in seconds between faucet requests on calibnet.
 const CALIBNET_COOLDOWN_SECONDS: i64 = 60; // 1 minute
 /// Time in seconds after which the wallet drip cap resets.
 const DRIP_CAP_RESET_SECONDS: i64 = 86400; // 24 hours

--- a/src/faucet/constants.rs
+++ b/src/faucet/constants.rs
@@ -52,6 +52,18 @@ impl FaucetInfo {
         }
     }
 
+    /// Returns the maximum amount of tokens that can be claimed by the wallet per day.
+    /// This is used to prevent the wallet from being drained completely and to ensure that the
+    /// faucet can continue to operate.
+    pub fn wallet_cap(&self) -> TokenAmount {
+        self.drip_amount() * 5
+    }
+
+    /// Returns the number of seconds after which the wallet cap resets for the faucet (24 hours).
+    pub fn wallet_limit_seconds(&self) -> i64 {
+        86400
+    }
+
     /// Returns the unit of the token for the given faucet.
     pub fn unit(&self) -> &str {
         match self {
@@ -140,6 +152,7 @@ mod tests {
         assert!(mainnet_faucet.transaction_base_url().is_none());
         assert_eq!(mainnet_faucet.token_type(), TokenType::Native);
         assert_eq!(mainnet_faucet.chain_id(), 314);
+        assert_eq!(mainnet_faucet.wallet_cap(), 5 * &*MAINNET_DRIP_AMOUNT);
 
         let calibnet_fil_faucet = FaucetInfo::CalibnetFIL;
         assert_eq!(calibnet_fil_faucet.drip_amount(), &*CALIBNET_DRIP_AMOUNT);
@@ -150,6 +163,7 @@ mod tests {
         assert!(calibnet_fil_faucet.transaction_base_url().is_none());
         assert_eq!(calibnet_fil_faucet.token_type(), TokenType::Native);
         assert_eq!(calibnet_fil_faucet.chain_id(), 314159);
+        assert_eq!(calibnet_fil_faucet.wallet_cap(), 5 * &*CALIBNET_DRIP_AMOUNT);
 
         let calibnet_usdfc_faucet = FaucetInfo::CalibnetUSDFC;
         assert_eq!(
@@ -172,5 +186,9 @@ mod tests {
             )
         );
         assert_eq!(calibnet_usdfc_faucet.chain_id(), 314159);
+        assert_eq!(
+            calibnet_usdfc_faucet.wallet_cap(),
+            5 * &*CALIBNET_USDFC_DRIP_AMOUNT
+        );
     }
 }

--- a/src/faucet/constants.rs
+++ b/src/faucet/constants.rs
@@ -15,17 +15,24 @@ static MAINNET_DRIP_AMOUNT: LazyLock<TokenAmount> =
 static CALIBNET_USDFC_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_whole(5));
 
-/// The multiplier applied to the number of tokens dripped per wallet every `reset_limiter_seconds`.
-/// This corresponds to 1 time of drip amount
-const MAINNET_WALLET_CAP_MULTIPLIER: i64 = 1;
-/// This corresponds to 2 time of drip amount
-const CALIBNET_WALLET_CAP_MULTIPLIER: i64 = 2;
+/// Multiplier to determine the maximum amount of tokens that can be dripped per wallet every [`FaucetInfo::reset_limiter_seconds`].
+/// This corresponds to 1 × [`FaucetInfo::drip_amount`]
+const MAINNET_PER_WALLET_DRIP_MULTIPLIER: i64 = 1;
+/// This corresponds to 2 × [`FaucetInfo::drip_amount`]
+const CALIBNET_PER_WALLET_DRIP_MULTIPLIER: i64 = 2;
 
-/// The multiplier applied to the number of tokens to be dripped every `reset_limiter_seconds`, all users combined.
-/// This corresponds to 2 times of drip amount
-const MAINNET_DRIP_CAP_MULTIPLIER: i64 = 2;
-/// This corresponds to 5 times of drip amount
-const CALIBNET_DRIP_CAP_MULTIPLIER: i64 = 5;
+/// Multiplier used to determine the maximum amount of tokens that can be dripped globally every [`FaucetInfo::reset_limiter_seconds`].
+/// This corresponds to 2 × [`FaucetInfo::drip_amount`]
+const MAINNET_GLOBAL_DRIP_MULTIPLIER: i64 = 2;
+/// This corresponds to 5 × [`FaucetInfo::drip_amount`]
+const CALIBNET_GLOBAL_DRIP_MULTIPLIER: i64 = 5;
+
+/// Cooldown duration in seconds between faucet requests on mainnet.
+const MAINNET_COOLDOWN_SECONDS: i64 = 600; // 10 minutes
+/// Cooldown duration in seconds between faucet requests on calibnet.
+const CALIBNET_COOLDOWN_SECONDS: i64 = 60; // 1 minute
+/// Time in seconds after which the wallet drip cap resets.
+const DRIP_CAP_RESET_SECONDS: i64 = 86400; // 24 hours
 
 pub type ContractAddress = alloy::primitives::Address;
 
@@ -58,37 +65,36 @@ impl FaucetInfo {
     /// which the faucet is temporarily disabled and no more drips can be sent.
     pub fn rate_limit_seconds(&self) -> i64 {
         match self {
-            FaucetInfo::MainnetFIL => 600,
-            FaucetInfo::CalibnetFIL => 60,
-            FaucetInfo::CalibnetUSDFC => 60,
+            FaucetInfo::MainnetFIL => MAINNET_COOLDOWN_SECONDS,
+            FaucetInfo::CalibnetFIL | FaucetInfo::CalibnetUSDFC => CALIBNET_COOLDOWN_SECONDS,
         }
     }
 
-    /// Returns the maximum amount of tokens that can be dripped by the wallet per `reset_limiter_seconds`.
+    /// Returns the maximum amount of tokens that can be dripped by the wallet per [`FaucetInfo::reset_limiter_seconds`].
     /// This is used to prevent the wallet from being drained completely and to ensure that the
     /// faucet can continue to operate.
     pub fn drip_cap(&self) -> TokenAmount {
         match self {
-            FaucetInfo::MainnetFIL => self.drip_amount() * MAINNET_DRIP_CAP_MULTIPLIER,
-            FaucetInfo::CalibnetFIL => self.drip_amount() * CALIBNET_DRIP_CAP_MULTIPLIER,
-            FaucetInfo::CalibnetUSDFC => self.drip_amount() * CALIBNET_DRIP_CAP_MULTIPLIER,
+            FaucetInfo::MainnetFIL => self.drip_amount() * MAINNET_GLOBAL_DRIP_MULTIPLIER,
+            FaucetInfo::CalibnetFIL => self.drip_amount() * CALIBNET_GLOBAL_DRIP_MULTIPLIER,
+            FaucetInfo::CalibnetUSDFC => self.drip_amount() * CALIBNET_GLOBAL_DRIP_MULTIPLIER,
         }
     }
 
-    /// Returns the maximum amount of tokens that can be claimed by the wallet per `reset_limiter_seconds`.
+    /// Returns the maximum amount of tokens that can be claimed by the wallet per [`FaucetInfo::reset_limiter_seconds`].
     /// This is used to prevent the wallet from being drained completely and to ensure that the
     /// faucet can continue to operate.
     pub fn wallet_cap(&self) -> TokenAmount {
         match self {
-            FaucetInfo::MainnetFIL => self.drip_amount() * MAINNET_WALLET_CAP_MULTIPLIER,
-            FaucetInfo::CalibnetFIL => self.drip_amount() * CALIBNET_WALLET_CAP_MULTIPLIER,
-            FaucetInfo::CalibnetUSDFC => self.drip_amount() * CALIBNET_WALLET_CAP_MULTIPLIER,
+            FaucetInfo::MainnetFIL => self.drip_amount() * MAINNET_PER_WALLET_DRIP_MULTIPLIER,
+            FaucetInfo::CalibnetFIL => self.drip_amount() * CALIBNET_PER_WALLET_DRIP_MULTIPLIER,
+            FaucetInfo::CalibnetUSDFC => self.drip_amount() * CALIBNET_PER_WALLET_DRIP_MULTIPLIER,
         }
     }
 
-    /// Returns the number of seconds after which the wallet cap resets for the faucet.
+    /// Returns the number of seconds after which the all drip cap resets for the faucet.
     pub fn reset_limiter_seconds(&self) -> i64 {
-        86400 // 24 hours
+        DRIP_CAP_RESET_SECONDS
     }
 
     /// Returns the unit of the token for the given faucet.
@@ -181,11 +187,11 @@ mod tests {
         assert_eq!(mainnet_faucet.chain_id(), 314);
         assert_eq!(
             mainnet_faucet.wallet_cap(),
-            MAINNET_WALLET_CAP_MULTIPLIER * &*MAINNET_DRIP_AMOUNT
+            MAINNET_PER_WALLET_DRIP_MULTIPLIER * &*MAINNET_DRIP_AMOUNT
         );
         assert_eq!(
             mainnet_faucet.drip_cap(),
-            MAINNET_DRIP_CAP_MULTIPLIER * &*MAINNET_DRIP_AMOUNT
+            MAINNET_GLOBAL_DRIP_MULTIPLIER * &*MAINNET_DRIP_AMOUNT
         );
 
         let calibnet_fil_faucet = FaucetInfo::CalibnetFIL;
@@ -199,11 +205,11 @@ mod tests {
         assert_eq!(calibnet_fil_faucet.chain_id(), 314159);
         assert_eq!(
             calibnet_fil_faucet.wallet_cap(),
-            CALIBNET_WALLET_CAP_MULTIPLIER * &*CALIBNET_DRIP_AMOUNT
+            CALIBNET_PER_WALLET_DRIP_MULTIPLIER * &*CALIBNET_DRIP_AMOUNT
         );
         assert_eq!(
             calibnet_fil_faucet.drip_cap(),
-            CALIBNET_DRIP_CAP_MULTIPLIER * &*CALIBNET_DRIP_AMOUNT
+            CALIBNET_GLOBAL_DRIP_MULTIPLIER * &*CALIBNET_DRIP_AMOUNT
         );
 
         let calibnet_usdfc_faucet = FaucetInfo::CalibnetUSDFC;
@@ -229,11 +235,11 @@ mod tests {
         assert_eq!(calibnet_usdfc_faucet.chain_id(), 314159);
         assert_eq!(
             calibnet_usdfc_faucet.wallet_cap(),
-            CALIBNET_WALLET_CAP_MULTIPLIER * &*CALIBNET_USDFC_DRIP_AMOUNT
+            CALIBNET_PER_WALLET_DRIP_MULTIPLIER * &*CALIBNET_USDFC_DRIP_AMOUNT
         );
         assert_eq!(
             calibnet_usdfc_faucet.drip_cap(),
-            CALIBNET_DRIP_CAP_MULTIPLIER * &*CALIBNET_USDFC_DRIP_AMOUNT
+            CALIBNET_GLOBAL_DRIP_MULTIPLIER * &*CALIBNET_USDFC_DRIP_AMOUNT
         );
     }
 }

--- a/src/faucet/constants.rs
+++ b/src/faucet/constants.rs
@@ -16,8 +16,10 @@ static CALIBNET_USDFC_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_whole(5));
 
 /// The multiplier applied to the number of tokens dripped per wallet every `wallet_limit_seconds`.
-/// This corresponds to 5 times of network drip amount.
-const WALLET_CAP_MULTIPLIER: i64 = 5;
+/// This corresponds to 2x of drip amount
+const MAINNET_WALLET_CAP_MULTIPLIER: i64 = 2;
+/// This corresponds to 5x of drip amount
+const CALIBNET_WALLET_CAP_MULTIPLIER: i64 = 5;
 
 pub type ContractAddress = alloy::primitives::Address;
 
@@ -60,7 +62,11 @@ impl FaucetInfo {
     /// This is used to prevent the wallet from being drained completely and to ensure that the
     /// faucet can continue to operate.
     pub fn wallet_cap(&self) -> TokenAmount {
-        self.drip_amount() * WALLET_CAP_MULTIPLIER
+        match self {
+            FaucetInfo::MainnetFIL => self.drip_amount() * MAINNET_WALLET_CAP_MULTIPLIER,
+            FaucetInfo::CalibnetFIL => self.drip_amount() * CALIBNET_WALLET_CAP_MULTIPLIER,
+            FaucetInfo::CalibnetUSDFC => self.drip_amount() * CALIBNET_WALLET_CAP_MULTIPLIER,
+        }
     }
 
     /// Returns the number of seconds after which the wallet cap resets for the faucet.
@@ -158,7 +164,7 @@ mod tests {
         assert_eq!(mainnet_faucet.chain_id(), 314);
         assert_eq!(
             mainnet_faucet.wallet_cap(),
-            WALLET_CAP_MULTIPLIER * &*MAINNET_DRIP_AMOUNT
+            MAINNET_WALLET_CAP_MULTIPLIER * &*MAINNET_DRIP_AMOUNT
         );
 
         let calibnet_fil_faucet = FaucetInfo::CalibnetFIL;
@@ -172,7 +178,7 @@ mod tests {
         assert_eq!(calibnet_fil_faucet.chain_id(), 314159);
         assert_eq!(
             calibnet_fil_faucet.wallet_cap(),
-            WALLET_CAP_MULTIPLIER * &*CALIBNET_DRIP_AMOUNT
+            CALIBNET_WALLET_CAP_MULTIPLIER * &*CALIBNET_DRIP_AMOUNT
         );
 
         let calibnet_usdfc_faucet = FaucetInfo::CalibnetUSDFC;
@@ -198,7 +204,7 @@ mod tests {
         assert_eq!(calibnet_usdfc_faucet.chain_id(), 314159);
         assert_eq!(
             calibnet_usdfc_faucet.wallet_cap(),
-            WALLET_CAP_MULTIPLIER * &*CALIBNET_USDFC_DRIP_AMOUNT
+            CALIBNET_WALLET_CAP_MULTIPLIER * &*CALIBNET_USDFC_DRIP_AMOUNT
         );
     }
 }

--- a/src/faucet/constants.rs
+++ b/src/faucet/constants.rs
@@ -16,7 +16,7 @@ static CALIBNET_USDFC_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_whole(5));
 
 /// The multiplier applied to the number of tokens dripped per wallet every `wallet_limit_seconds`.
-/// This corresponds to 5x of network drip amount.
+/// This corresponds to 5 times of network drip amount.
 const WALLET_CAP_MULTIPLIER: i64 = 5;
 
 pub type ContractAddress = alloy::primitives::Address;

--- a/src/faucet/controller.rs
+++ b/src/faucet/controller.rs
@@ -1,5 +1,7 @@
 use super::constants::{FaucetInfo, TokenType};
-use super::server_api::{faucet_address, signed_erc20_transfer, signed_fil_transfer};
+use super::server_api::{
+    check_rate_limit, faucet_address, signed_erc20_transfer, signed_fil_transfer,
+};
 use crate::faucet::model::FaucetModel;
 use crate::utils::address::AddressAlloyExt;
 use crate::utils::lotus_json::LotusJson;
@@ -228,27 +230,29 @@ impl FaucetController {
                         let nonce = rpc.mpool_get_nonce(from).await?;
                         let raw_msg = message_transfer(from, recipient, info.drip_amount().clone());
                         let msg = rpc.estimate_gas(raw_msg).await?;
-                        match signed_fil_transfer(
-                            LotusJson(recipient),
-                            msg.gas_limit,
-                            LotusJson(msg.gas_fee_cap),
-                            LotusJson(msg.gas_premium),
-                            nonce,
-                            info,
-                        )
-                        .await
-                        {
-                            Ok(LotusJson(signed)) => {
+                        let rate_limit_seconds = check_rate_limit(info, recipient.id()?)
+                            .await
+                            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+                        match rate_limit_seconds {
+                            Some(rate_limit) => {
+                                faucet.send_limited.set(rate_limit);
+                            }
+                            None => {
+                                let LotusJson(signed) = signed_fil_transfer(
+                                    LotusJson(recipient),
+                                    msg.gas_limit,
+                                    LotusJson(msg.gas_fee_cap),
+                                    LotusJson(msg.gas_premium),
+                                    nonce,
+                                    info,
+                                )
+                                .await
+                                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
                                 let cid = rpc.mpool_push(signed).await?;
                                 faucet.sent_messages.update(|messages| {
                                     messages.push((TransactionId::Native(cid), false));
                                 });
                                 log::info!("Sent message: {:?}", cid);
-                            }
-                            Err(e) => {
-                                console_log(&format!("Failed to sign message: {}", e));
-                                let rate_limit_seconds = info.rate_limit_seconds();
-                                faucet.send_limited.set(rate_limit_seconds as i32);
                             }
                         }
                         Ok(())
@@ -288,22 +292,23 @@ impl FaucetController {
                         let nonce = filecoin_rpc.mpool_get_nonce(owner_fil_address).await?;
                         let gas_price = filecoin_rpc.gas_price().await?;
                         let eth_to = recipient.into_eth_address()?;
-
-                        match signed_erc20_transfer(eth_to, nonce, gas_price, info, recipient.id()?)
+                        let rate_limit_seconds = check_rate_limit(info, recipient.id()?)
                             .await
-                        {
-                            Ok(signed) => {
+                            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+                        match rate_limit_seconds {
+                            Some(rate_limit) => {
+                                faucet.send_limited.set(rate_limit);
+                            }
+                            None => {
+                                let signed = signed_erc20_transfer(eth_to, nonce, gas_price, info)
+                                    .await
+                                    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
                                 let tx_id =
                                     filecoin_rpc.send_eth_transaction_signed(&signed).await?;
                                 faucet.sent_messages.update(|messages| {
                                     messages.push((TransactionId::Eth(tx_id), false));
                                 });
                                 console_log(&format!("Transaction sent successfully: {tx_id}"));
-                            }
-                            Err(e) => {
-                                console_log(&format!("Failed to create signed transaction: {e}"));
-                                let rate_limit_seconds = info.rate_limit_seconds();
-                                faucet.send_limited.set(rate_limit_seconds as i32);
                             }
                         }
                         Ok(())

--- a/src/faucet/rate_limiter.rs
+++ b/src/faucet/rate_limiter.rs
@@ -110,7 +110,7 @@ impl DurableObject for RateLimiter {
             self.update_rate_limit(&faucet_info, &id, now, claimed)
                 .await?;
         }
-        return Response::from_json(&retry_after);
+        Response::from_json(&retry_after)
     }
 
     async fn alarm(&self) -> Result<Response> {

--- a/src/faucet/rate_limiter.rs
+++ b/src/faucet/rate_limiter.rs
@@ -70,7 +70,7 @@ impl DurableObject for RateLimiter {
             }
             return Response::from_json(&is_allowed);
         }
-
+        console_log!("{faucet_info} Rate limiter for {id} invoked: Wallet capped now={now:?}, claimed={claimed:?}");
         Response::from_json(&false)
     }
 

--- a/src/faucet/rate_limiter.rs
+++ b/src/faucet/rate_limiter.rs
@@ -10,7 +10,7 @@ use worker::*;
 #[cfg(test)]
 use mockall::automock;
 
-/// Abstraction for storage backends used by the rate limiter.
+/// Abstraction for storage backend used by the rate limiter.
 /// This trait allows the rate limiter logic to be decoupled from the underlying storage implementation.
 /// Implementations may use [`DurableObjectStorage`], in-memory mocks, or other storage systems.
 #[cfg_attr(test, automock)]

--- a/src/faucet/rate_limiter.rs
+++ b/src/faucet/rate_limiter.rs
@@ -68,7 +68,7 @@ impl DurableObject for RateLimiter {
                 console_log!(
                 "{faucet_info} Rate limiter for {id} invoked: now={now:?}, block_until={block_until:?}, claimed={claimed:?}, may_sign={is_allowed:?}"
             );
-                retry_after = Some(block_until.signed_duration_since(&now).num_seconds());
+                retry_after = Some(block_until.signed_duration_since(now).num_seconds());
             }
             return Response::from_json(&Some(retry_after));
         }

--- a/src/faucet/rate_limiter.rs
+++ b/src/faucet/rate_limiter.rs
@@ -2,18 +2,76 @@
 use std::str::FromStr as _;
 
 use crate::faucet::constants::FaucetInfo;
+use crate::utils::lotus_json::LotusJson;
 use chrono::{DateTime, Duration, Utc};
 use fvm_shared::econ::TokenAmount;
 use worker::*;
 
-#[durable_object]
-pub struct RateLimiter {
-    state: State,
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg_attr(test, automock)]
+#[async_trait::async_trait(?Send)]
+pub trait RateLimiterStorage {
+    async fn get<T>(&self, key: &str) -> Result<Option<T>>
+    where
+        T: for<'de> serde::Deserialize<'de> + 'static;
+    async fn put<T>(&self, key: &str, value: T) -> Result<()>
+    where
+        T: serde::Serialize + 'static;
+    async fn get_alarm(&self) -> Result<Option<i64>>;
+    async fn set_alarm(&self, duration: std::time::Duration) -> Result<()>;
+    async fn delete_all(&self) -> Result<()>;
 }
 
-impl RateLimiter {
-    fn parse_request_path(path: &str) -> Result<(FaucetInfo, String)> {
-        // Request path format: http://do/rate_limiter/{faucet_info}/{id}
+#[cfg(not(test))]
+pub struct DurableObjectStorage<'a> {
+    state: &'a State,
+}
+
+#[cfg(not(test))]
+impl<'a> DurableObjectStorage<'a> {
+    pub fn new(state: &'a State) -> Self {
+        Self { state }
+    }
+}
+
+#[cfg(not(test))]
+#[async_trait::async_trait(?Send)]
+impl<'a> RateLimiterStorage for DurableObjectStorage<'a> {
+    async fn get<T>(&self, key: &str) -> Result<Option<T>>
+    where
+        T: for<'de> serde::Deserialize<'de>,
+    {
+        self.state.storage().get(key).await
+    }
+    async fn put<T>(&self, key: &str, value: T) -> Result<()>
+    where
+        T: serde::Serialize,
+    {
+        self.state.storage().put(key, value).await
+    }
+    async fn get_alarm(&self) -> Result<Option<i64>> {
+        self.state.storage().get_alarm().await
+    }
+    async fn set_alarm(&self, duration: std::time::Duration) -> Result<()> {
+        self.state.storage().set_alarm(duration).await
+    }
+    async fn delete_all(&self) -> Result<()> {
+        self.state.storage().delete_all().await
+    }
+}
+
+pub struct RateLimiterCore<S: RateLimiterStorage> {
+    storage: S,
+}
+
+impl<S: RateLimiterStorage> RateLimiterCore<S> {
+    pub fn new(storage: S) -> Self {
+        Self { storage }
+    }
+
+    pub fn parse_request_path(path: &str) -> Result<(FaucetInfo, String)> {
         let mut path_info = path.split('/');
         let id = path_info.next_back().unwrap_or_default().to_string();
         let faucet_info = FaucetInfo::from_str(path_info.next_back().unwrap_or_default())
@@ -27,51 +85,61 @@ impl RateLimiter {
         id: &str,
         now: DateTime<Utc>,
     ) -> Result<(bool, Option<i64>, TokenAmount, TokenAmount)> {
-        let dripped: TokenAmount = self
-            .state
-            .storage()
-            .get("dripped")
+        let dripped = self
+            .storage
+            .get::<LotusJson<TokenAmount>>("dripped")
             .await
-            .unwrap_or(TokenAmount::default());
-        let claimed_key = format!("claimed_{id}");
-        let claimed: TokenAmount = self
-            .state
-            .storage()
-            .get(&claimed_key)
+            .ok()
+            .flatten()
+            .map(|v| v.into_inner())
+            .unwrap_or_default();
+        let claimed = self
+            .storage
+            .get::<LotusJson<TokenAmount>>(&format!("claimed_{id}"))
             .await
-            .unwrap_or(TokenAmount::default());
+            .ok()
+            .flatten()
+            .map(|v| v.into_inner())
+            .unwrap_or_default();
         if dripped >= faucet_info.drip_cap() {
-            let drip_block_until = self.state.storage().get_alarm().await?.unwrap_or_default();
-            let retry_after =
-                Duration::milliseconds(drip_block_until - now.timestamp_millis()).num_seconds();
-            console_log!("{faucet_info} Rate limiter for {id} invoked: Drip capped now={now:?}, dripped={dripped:?}, retry_after={retry_after:?}");
+            let retry_after = self
+                .storage
+                .get_alarm()
+                .await
+                .ok()
+                .flatten()
+                .map(|alarm| Duration::milliseconds(alarm - now.timestamp_millis()).num_seconds())
+                .unwrap_or(0);
+            log::info!("{faucet_info} Rate limiter for {id} invoked: Drip capped now={now:?}, dripped={dripped:?}, retry_after={retry_after:?}");
             return Ok((false, Some(retry_after), claimed, dripped));
         }
-
         if claimed >= faucet_info.wallet_cap() {
-            let wallet_block_until = self.state.storage().get_alarm().await?.unwrap_or_default();
-            let retry_after =
-                Duration::milliseconds(wallet_block_until - now.timestamp_millis()).num_seconds();
-            console_log!("{faucet_info} Rate limiter for {id} invoked: Wallet capped now={now:?}, claimed={claimed:?}, retry_after={retry_after:?}");
+            let retry_after = self
+                .storage
+                .get_alarm()
+                .await
+                .ok()
+                .flatten()
+                .map(|alarm| Duration::milliseconds(alarm - now.timestamp_millis()).num_seconds())
+                .unwrap_or(0);
+            log::info!("{faucet_info} Rate limiter for {id} invoked: Wallet capped now={now:?}, claimed={claimed:?}, retry_after={retry_after:?}");
             return Ok((false, Some(retry_after), claimed, dripped));
         }
-
         let block_until = self
-            .state
-            .storage()
-            .get("block_until")
+            .storage
+            .get::<i64>("block_until")
             .await
-            .map(|v| DateTime::<Utc>::from_timestamp(v, 0).unwrap_or_default())
+            .ok()
+            .flatten()
+            .and_then(|secs| DateTime::<Utc>::from_timestamp(secs, 0))
             .unwrap_or(now);
-
         if block_until > now {
             let retry_after = block_until.signed_duration_since(now).num_seconds();
-            console_log!(
+            log::info!(
                 "{faucet_info} Rate limiter for {id} invoked: now={now:?}, claimed={claimed:?}, retry_after={retry_after:?}"
             );
             return Ok((false, Some(retry_after), claimed, dripped));
         }
-
         Ok((true, None, claimed, dripped))
     }
 
@@ -86,33 +154,84 @@ impl RateLimiter {
         let update_dripped = dripped + faucet_info.drip_amount();
         let updated_claimed = claimed + faucet_info.drip_amount();
         let next_block = now + Duration::seconds(faucet_info.rate_limit_seconds());
-
-        self.state
-            .storage()
-            .put("dripped", update_dripped.clone())
+        self.storage
+            .put("dripped", LotusJson(update_dripped.clone()))
             .await?;
-        self.state
-            .storage()
-            .put(&format!("claimed_{id}"), updated_claimed.clone())
+        self.storage
+            .put(&format!("claimed_{id}"), LotusJson(updated_claimed.clone()))
             .await?;
-        self.state
-            .storage()
+        self.storage
             .put("block_until", next_block.timestamp())
             .await?;
-
-        if self.state.storage().get_alarm().await?.is_none() {
-            self.state
-                .storage()
+        if self.storage.get_alarm().await?.is_none() {
+            self.storage
                 .set_alarm(std::time::Duration::from_secs(
                     faucet_info.reset_limiter_seconds() as u64,
                 ))
                 .await?;
         }
-        console_log!("{faucet_info} Rate limiter for {id} set: now={now:?}, block_until={next_block:?}, claimed={updated_claimed:?}, dripped={update_dripped:?}");
+        log::info!("{faucet_info} Rate limiter for {id} set: now={now:?}, block_until={next_block:?}, claimed={updated_claimed:?}, dripped={update_dripped:?}");
         Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub async fn handle_request(&self, path: &str, now: DateTime<Utc>) -> Result<Option<i64>> {
+        let (faucet_info, id) = Self::parse_request_path(path)?;
+        let (is_allowed, retry_after, claimed, dripped) =
+            self.get_rate_limit(&faucet_info, &id, now).await?;
+        if is_allowed {
+            self.update_rate_limit(&faucet_info, &id, now, claimed, dripped)
+                .await?;
+        }
+        Ok(retry_after)
+    }
+
+    #[allow(dead_code)]
+    pub async fn handle_alarm(&self) -> Result<()> {
+        log::info!("Rate limiter alarm triggered. DurableObject will be deleted.");
+        self.storage.delete_all().await
     }
 }
 
+#[durable_object]
+pub struct RateLimiter {
+    #[cfg(not(test))]
+    state: State,
+}
+
+#[cfg(not(test))]
+impl RateLimiter {
+    fn parse_request_path(path: &str) -> Result<(FaucetInfo, String)> {
+        RateLimiterCore::<DurableObjectStorage>::parse_request_path(path)
+    }
+    fn create_core(&self) -> RateLimiterCore<DurableObjectStorage> {
+        RateLimiterCore::new(DurableObjectStorage::new(&self.state))
+    }
+    async fn get_rate_limit(
+        &self,
+        faucet_info: &FaucetInfo,
+        id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(bool, Option<i64>, TokenAmount, TokenAmount)> {
+        self.create_core()
+            .get_rate_limit(faucet_info, id, now)
+            .await
+    }
+    async fn update_rate_limit(
+        &self,
+        faucet_info: &FaucetInfo,
+        id: &str,
+        now: DateTime<Utc>,
+        claimed: TokenAmount,
+        dripped: TokenAmount,
+    ) -> Result<()> {
+        self.create_core()
+            .update_rate_limit(faucet_info, id, now, claimed, dripped)
+            .await
+    }
+}
+
+#[cfg(not(test))]
 impl DurableObject for RateLimiter {
     fn new(state: State, _env: Env) -> Self {
         Self { state }
@@ -135,5 +254,554 @@ impl DurableObject for RateLimiter {
         console_log!("Rate limiter alarm triggered. DurableObject will be deleted.");
         self.state.storage().delete_all().await.ok();
         Response::ok("OK")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_traits::cast::ToPrimitive;
+    use std::ops::AddAssign;
+
+    impl DurableObject for RateLimiter {
+        fn new(_state: State, _env: Env) -> Self {
+            panic!("Not required in tests");
+        }
+        fn fetch(&self, _req: Request) -> impl std::future::Future<Output = Result<Response>> {
+            async { panic!("Not required in tests") }
+        }
+        fn alarm(&self) -> impl std::future::Future<Output = Result<Response>> {
+            async { panic!("Not required in tests") }
+        }
+    }
+
+    struct MockStorageConfig<'a> {
+        dripped: Option<TokenAmount>,
+        claimed: Option<TokenAmount>,
+        block_until: Option<i64>,
+        alarm: Option<i64>,
+        wallet_id: &'a str,
+        // If true, expect puts and set_alarm (for allowed requests)
+        expect_puts: bool,
+    }
+
+    fn new_mock_storage(config: MockStorageConfig) -> MockRateLimiterStorage {
+        let mut mock_storage = MockRateLimiterStorage::new();
+        mock_storage
+            .expect_get::<LotusJson<TokenAmount>>()
+            .with(mockall::predicate::eq("dripped"))
+            .returning(move |_| Ok(config.dripped.clone().map(LotusJson)));
+        mock_storage
+            .expect_get::<LotusJson<TokenAmount>>()
+            .with(mockall::predicate::eq(format!(
+                "claimed_{}",
+                config.wallet_id
+            )))
+            .returning(move |_| Ok(config.claimed.clone().map(LotusJson)));
+        mock_storage
+            .expect_get::<i64>()
+            .with(mockall::predicate::eq("block_until"))
+            .returning(move |_| Ok(config.block_until));
+        mock_storage
+            .expect_get_alarm()
+            .returning(move || Ok(config.alarm));
+        if config.expect_puts {
+            mock_storage
+                .expect_put::<LotusJson<TokenAmount>>()
+                .with(
+                    mockall::predicate::eq("dripped"),
+                    mockall::predicate::always(),
+                )
+                .returning(|_, _| Ok(()));
+            mock_storage
+                .expect_put::<LotusJson<TokenAmount>>()
+                .with(
+                    mockall::predicate::eq(format!("claimed_{}", config.wallet_id)),
+                    mockall::predicate::always(),
+                )
+                .returning(|_, _| Ok(()));
+            mock_storage
+                .expect_put::<i64>()
+                .with(
+                    mockall::predicate::eq("block_until"),
+                    mockall::predicate::always(),
+                )
+                .returning(|_, _| Ok(()));
+            mock_storage.expect_set_alarm().returning(|_| Ok(()));
+        }
+        mock_storage
+    }
+
+    /// Checks that the initial request is allowed when storage is empty (no rate limiting).
+    #[tokio::test]
+    async fn test_rate_limiter_initial_request() {
+        let wallet_id = "test_wallet";
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: None,
+            claimed: None,
+            block_until: None,
+            alarm: None,
+            wallet_id,
+            expect_puts: true,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let now = Utc::now();
+        let path = "http://do/rate_limiter/CalibnetFIL/test_wallet";
+        let result = core.handle_request(path, now).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    /// Checks that a request is rate limited if block_until is in the future (cooldown period).
+    #[tokio::test]
+    async fn test_rate_limiter_cooldown_period() {
+        let wallet_id = "test_wallet";
+        let now = Utc::now();
+        let future_time = now + Duration::seconds(30);
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: None,
+            claimed: None,
+            block_until: Some(future_time.timestamp()),
+            alarm: None,
+            wallet_id,
+            expect_puts: false,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let path = "http://do/rate_limiter/CalibnetFIL/test_wallet";
+        let result = core.handle_request(path, now).await.unwrap();
+        assert!(result.is_some());
+        let retry_after = result.unwrap();
+        assert!(retry_after > 0);
+        assert!(retry_after <= 30);
+    }
+
+    /// Checks that a request is rate limited if the wallet cap is exceeded.
+    #[tokio::test]
+    async fn test_rate_limiter_wallet_cap_exceeded() {
+        let now = Utc::now();
+        let path = "http://do/rate_limiter/CalibnetFIL/test_wallet";
+        let faucet_info = FaucetInfo::CalibnetFIL;
+        let exceeded_amount = faucet_info.wallet_cap() + TokenAmount::from_whole(1);
+        let alarm_time = now.timestamp_millis() + 3600 * 1000; // 1 hour from now
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: None,
+            claimed: Some(exceeded_amount.clone()),
+            block_until: None,
+            alarm: Some(alarm_time),
+            wallet_id: "test_wallet",
+            expect_puts: false,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let result = core.handle_request(path, now).await.unwrap();
+        assert!(result.is_some());
+        let retry_after = result.unwrap();
+        assert!(retry_after > 0);
+        assert!(retry_after <= 3600);
+    }
+
+    /// Checks that a request is rate limited if the global drip cap is exceeded.
+    #[tokio::test]
+    async fn test_rate_limiter_drip_cap_exceeded() {
+        let now = Utc::now();
+        let path = "http://do/rate_limiter/CalibnetFIL/test_wallet";
+        let faucet_info = FaucetInfo::CalibnetFIL;
+        let exceeded_amount = faucet_info.drip_cap() + TokenAmount::from_whole(1);
+        let alarm_time = now.timestamp_millis() + 7200 * 1000; // 2 hours from now
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: Some(exceeded_amount.clone()),
+            claimed: None,
+            block_until: None,
+            alarm: Some(alarm_time),
+            wallet_id: "test_wallet",
+            expect_puts: false,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let result = core.handle_request(path, now).await.unwrap();
+        assert!(result.is_some());
+        let retry_after = result.unwrap();
+        assert!(retry_after > 0);
+        assert!(retry_after <= 7200);
+    }
+
+    /// Checks that a successful request updates storage as expected.
+    #[tokio::test]
+    async fn test_rate_limiter_successful_request_updates_storage() {
+        let now = Utc::now();
+        let path = "http://do/rate_limiter/CalibnetFIL/test_wallet";
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: None,
+            claimed: None,
+            block_until: None,
+            alarm: None,
+            wallet_id: "test_wallet",
+            expect_puts: true,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let result = core.handle_request(path, now).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    /// Checks that parse_request_path correctly parses a valid path.
+    #[tokio::test]
+    async fn test_parse_request_path() {
+        let path = "http://do/rate_limiter/CalibnetFIL/test_wallet_123";
+        let (faucet_info, id) =
+            RateLimiterCore::<MockRateLimiterStorage>::parse_request_path(path).unwrap();
+        assert_eq!(faucet_info, FaucetInfo::CalibnetFIL);
+        assert_eq!(id, "test_wallet_123");
+    }
+
+    /// Checks that parse_request_path returns an error for an invalid faucet.
+    #[tokio::test]
+    async fn test_parse_request_path_invalid_faucet() {
+        let path = "http://do/rate_limiter/InvalidFaucet/test_wallet";
+        let result = RateLimiterCore::<MockRateLimiterStorage>::parse_request_path(path);
+        assert!(result.is_err());
+    }
+
+    /// Checks that the alarm handler calls delete_all on storage.
+    #[tokio::test]
+    async fn test_alarm_handler() {
+        let mut mock_storage = MockRateLimiterStorage::new();
+        mock_storage.expect_delete_all().returning(|| Ok(()));
+        let core = RateLimiterCore::new(mock_storage);
+        core.handle_alarm().await.unwrap();
+    }
+
+    /// Simulates a single user's journey to the wallet cap, ensuring rate limiting is enforced at the cap.
+    #[tokio::test]
+    async fn test_user_journey_to_wallet_cap() {
+        let faucet_info = FaucetInfo::CalibnetFIL;
+        let wallet_id = "test_wallet_123";
+        let path = format!("http://do/rate_limiter/{faucet_info}/{wallet_id}");
+        let wallet_cap_requests = (faucet_info.wallet_cap().atto()
+            / faucet_info.drip_amount().atto())
+        .to_u64()
+        .unwrap() as usize;
+
+        let mut claimed = TokenAmount::default();
+        let mut dripped = TokenAmount::default();
+
+        // For each request up to wallet cap
+        for _ in 0..wallet_cap_requests {
+            let mock_storage = new_mock_storage(MockStorageConfig {
+                dripped: None,
+                claimed: None,
+                block_until: None,
+                alarm: None,
+                wallet_id,
+                expect_puts: true,
+            });
+            let core = RateLimiterCore::new(mock_storage);
+            let now = chrono::Utc::now();
+            let result = core.handle_request(&path, now).await.unwrap();
+            assert!(result.is_none());
+            claimed = claimed + faucet_info.drip_amount();
+            dripped = dripped + faucet_info.drip_amount();
+        }
+
+        // Final request should hit wallet cap
+        let mut mock_storage = MockRateLimiterStorage::new();
+        let dripped_clone = dripped.clone();
+        mock_storage
+            .expect_get::<LotusJson<TokenAmount>>()
+            .with(mockall::predicate::eq("dripped"))
+            .returning(move |_| Ok(Some(LotusJson(dripped_clone.clone()))));
+        let claimed_clone = claimed.clone();
+        mock_storage
+            .expect_get::<LotusJson<TokenAmount>>()
+            .with(mockall::predicate::eq(format!("claimed_{}", wallet_id)))
+            .returning(move |_| Ok(Some(LotusJson(claimed_clone.clone()))));
+        let alarm_time =
+            chrono::Utc::now().timestamp_millis() + faucet_info.reset_limiter_seconds() * 1000;
+        mock_storage
+            .expect_get_alarm()
+            .returning(move || Ok(Some(alarm_time)));
+        let core = RateLimiterCore::new(mock_storage);
+        let now = chrono::Utc::now();
+        let result = core.handle_request(&path, now).await.unwrap();
+        assert!(result.is_some());
+        let retry_after = result.unwrap();
+        assert!(retry_after > 0 && retry_after <= faucet_info.reset_limiter_seconds());
+    }
+
+    /// Simulates multiple users claiming up to the global drip cap, ensuring all are rate limited at the cap.
+    #[tokio::test]
+    async fn test_multiple_user_journey_to_drip_cap() {
+        let faucet_info = FaucetInfo::CalibnetFIL;
+        let wallet_1 = "wallet_1";
+        let wallet_2 = "wallet_2";
+        let wallet_3 = "wallet_3";
+        let wallet_cap_requests = (faucet_info.wallet_cap().atto()
+            / faucet_info.drip_amount().atto())
+        .to_u64()
+        .unwrap() as usize;
+        let mut dripped = TokenAmount::default();
+        let mut claimed_1 = TokenAmount::default();
+        let mut claimed_2 = TokenAmount::default();
+        let mut claimed_3 = TokenAmount::default();
+
+        // Wallet 1: Up to wallet cap
+        for _ in 0..wallet_cap_requests {
+            let mock_storage = new_mock_storage(MockStorageConfig {
+                dripped: None,
+                claimed: None,
+                block_until: None,
+                alarm: None,
+                wallet_id: wallet_1,
+                expect_puts: true,
+            });
+            let core = RateLimiterCore::new(mock_storage);
+            let now = chrono::Utc::now();
+            let result = core
+                .handle_request(
+                    &format!("http://do/rate_limiter/{faucet_info}/{wallet_1}"),
+                    now,
+                )
+                .await
+                .unwrap();
+            assert!(result.is_none());
+            claimed_1 = claimed_1 + faucet_info.drip_amount();
+            dripped = dripped + faucet_info.drip_amount();
+        }
+        // Wallet 2: Up to wallet cap
+        for _ in 0..wallet_cap_requests {
+            if dripped >= faucet_info.drip_cap() {
+                break;
+            }
+            let mock_storage = new_mock_storage(MockStorageConfig {
+                dripped: None,
+                claimed: None,
+                block_until: None,
+                alarm: None,
+                wallet_id: wallet_2,
+                expect_puts: true,
+            });
+            let core = RateLimiterCore::new(mock_storage);
+            let now = chrono::Utc::now();
+            let result = core
+                .handle_request(
+                    &format!("http://do/rate_limiter/{faucet_info}/{wallet_2}"),
+                    now,
+                )
+                .await
+                .unwrap();
+            assert!(result.is_none());
+            claimed_2 = claimed_2 + faucet_info.drip_amount();
+            dripped = dripped + faucet_info.drip_amount();
+        }
+        // Wallet 3: Up to drip cap
+        while dripped < faucet_info.drip_cap() {
+            let mock_storage = new_mock_storage(MockStorageConfig {
+                dripped: None,
+                claimed: None,
+                block_until: None,
+                alarm: None,
+                wallet_id: wallet_3,
+                expect_puts: true,
+            });
+            let core = RateLimiterCore::new(mock_storage);
+            let now = chrono::Utc::now();
+            let result = core
+                .handle_request(
+                    &format!("http://do/rate_limiter/{faucet_info}/{wallet_3}"),
+                    now,
+                )
+                .await
+                .unwrap();
+            assert!(result.is_none());
+            claimed_3 = claimed_3 + faucet_info.drip_amount();
+            dripped = dripped + faucet_info.drip_amount();
+        }
+        // Now all wallets should be rate limited due to drip cap
+        for wallet in [wallet_1, wallet_2, wallet_3] {
+            let mut mock_storage = MockRateLimiterStorage::new();
+            let dripped_clone = dripped.clone();
+            let claimed_clone = match wallet {
+                w if w == wallet_1 => claimed_1.clone(),
+                w if w == wallet_2 => claimed_2.clone(),
+                _ => claimed_3.clone(),
+            };
+            mock_storage
+                .expect_get::<LotusJson<TokenAmount>>()
+                .with(mockall::predicate::eq("dripped"))
+                .returning(move |_| Ok(Some(LotusJson(dripped_clone.clone()))));
+            mock_storage
+                .expect_get::<LotusJson<TokenAmount>>()
+                .with(mockall::predicate::eq(format!("claimed_{}", wallet)))
+                .returning(move |_| Ok(Some(LotusJson(claimed_clone.clone()))));
+            let alarm_time =
+                chrono::Utc::now().timestamp_millis() + faucet_info.reset_limiter_seconds() * 1000;
+            mock_storage
+                .expect_get_alarm()
+                .returning(move || Ok(Some(alarm_time)));
+            let core = RateLimiterCore::new(mock_storage);
+            let now = chrono::Utc::now();
+            let result = core
+                .handle_request(
+                    &format!("http://do/rate_limiter/{faucet_info}/{wallet}"),
+                    now,
+                )
+                .await
+                .unwrap();
+            assert!(result.is_some());
+        }
+    }
+
+    /// Simulates reaching the drip cap, triggering the alarm reset, and verifies new requests are allowed after reset.
+    #[tokio::test]
+    async fn test_alarm_reset_cycle() {
+        let faucet_info = FaucetInfo::CalibnetFIL;
+        let wallets = ["wallet_1", "wallet_2", "wallet_3", "wallet_4", "wallet_5"];
+        let mut dripped = TokenAmount::default();
+        let mut claimed = std::collections::HashMap::new();
+        for &wallet in &wallets {
+            claimed.insert(wallet, TokenAmount::default());
+        }
+        // Use multiple wallets to reach the global cap
+        'outer: for &wallet in &wallets {
+            for _ in 0..2 {
+                if dripped >= faucet_info.drip_cap() {
+                    break 'outer;
+                }
+                let mock_storage = new_mock_storage(MockStorageConfig {
+                    dripped: None,
+                    claimed: None,
+                    block_until: None,
+                    alarm: None,
+                    wallet_id: wallet,
+                    expect_puts: true,
+                });
+                let core = RateLimiterCore::new(mock_storage);
+                let now = chrono::Utc::now();
+                let result = core
+                    .handle_request(
+                        &format!("http://do/rate_limiter/{faucet_info}/{}", wallet),
+                        now,
+                    )
+                    .await
+                    .unwrap();
+                assert!(result.is_none());
+                claimed
+                    .get_mut(wallet)
+                    .unwrap()
+                    .add_assign(faucet_info.drip_amount());
+                dripped = dripped + faucet_info.drip_amount();
+            }
+        }
+        // Verify drip cap is reached
+        let mut mock_storage = MockRateLimiterStorage::new();
+        let dripped_clone = dripped.clone();
+        let claimed_clone = claimed["wallet_1"].clone();
+        mock_storage
+            .expect_get::<LotusJson<TokenAmount>>()
+            .with(mockall::predicate::eq("dripped"))
+            .returning(move |_| Ok(Some(LotusJson(dripped_clone.clone()))));
+        mock_storage
+            .expect_get::<LotusJson<TokenAmount>>()
+            .with(mockall::predicate::eq(format!("claimed_{}", "wallet_1")))
+            .returning(move |_| Ok(Some(LotusJson(claimed_clone.clone()))));
+        let alarm_time =
+            chrono::Utc::now().timestamp_millis() + faucet_info.reset_limiter_seconds() * 1000;
+        mock_storage
+            .expect_get_alarm()
+            .returning(move || Ok(Some(alarm_time)));
+        let core = RateLimiterCore::new(mock_storage);
+        let now = chrono::Utc::now();
+        let result = core
+            .handle_request(
+                &format!("http://do/rate_limiter/{faucet_info}/wallet_1"),
+                now,
+            )
+            .await
+            .unwrap();
+        assert!(result.is_some());
+        // Simulate alarm handler
+        let mut mock_storage = MockRateLimiterStorage::new();
+        mock_storage.expect_delete_all().returning(|| Ok(()));
+        let core = RateLimiterCore::new(mock_storage);
+        core.handle_alarm().await.unwrap();
+        // After alarm, new request should be allowed (storage is reset)
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: None,
+            claimed: None,
+            block_until: None,
+            alarm: None,
+            wallet_id: "wallet_1",
+            expect_puts: true,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let now = chrono::Utc::now();
+        let result = core
+            .handle_request(
+                &format!("http://do/rate_limiter/{faucet_info}/wallet_1"),
+                now,
+            )
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    /// Simulates the cooldown period: allowed, blocked, partially blocked, then allowed again.
+    #[tokio::test]
+    async fn test_cooldown_period_progression() {
+        let faucet_info = FaucetInfo::CalibnetFIL;
+        let wallet_id = "cooldown_test_wallet";
+        let path = format!("http://do/rate_limiter/{faucet_info}/{wallet_id}");
+        let now = chrono::Utc::now();
+        // Step 1: First request (should succeed)
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: None,
+            claimed: None,
+            block_until: None,
+            alarm: None,
+            wallet_id,
+            expect_puts: true,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let result_1 = core.handle_request(&path, now).await.unwrap();
+        assert!(result_1.is_none());
+        // Step 2: Immediate retry (should be rate limited)
+        let block_until = now + chrono::Duration::seconds(faucet_info.rate_limit_seconds());
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: None,
+            claimed: None,
+            block_until: Some(block_until.timestamp()),
+            alarm: None,
+            wallet_id,
+            expect_puts: false,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let result_2 = core.handle_request(&path, now).await.unwrap();
+        assert!(result_2.is_some());
+        let retry_2 = result_2.unwrap();
+        assert!(retry_2 > 0 && retry_2 <= faucet_info.rate_limit_seconds());
+        // Step 3: Partial cooldown (should still be rate limited, less time left)
+        let partial_block_until = now + chrono::Duration::seconds(1); // 1 second in the future
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: None,
+            claimed: None,
+            block_until: Some(partial_block_until.timestamp()),
+            alarm: None,
+            wallet_id,
+            expect_puts: false,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let result_3 = core.handle_request(&path, now).await.unwrap();
+        assert!(result_3.is_some());
+        let retry_3 = result_3.unwrap();
+        assert!(retry_3 >= 0 && retry_3 <= 1);
+        assert!(retry_3 < retry_2);
+        let past_block_until = now - chrono::Duration::seconds(1);
+        let mock_storage = new_mock_storage(MockStorageConfig {
+            dripped: None,
+            claimed: None,
+            block_until: Some(past_block_until.timestamp()),
+            alarm: None,
+            wallet_id,
+            expect_puts: true,
+        });
+        let core = RateLimiterCore::new(mock_storage);
+        let result_4 = core.handle_request(&path, now).await.unwrap();
+        assert!(result_4.is_none());
     }
 }

--- a/src/faucet/rate_limiter.rs
+++ b/src/faucet/rate_limiter.rs
@@ -27,11 +27,10 @@ impl RateLimiter {
         id: &str,
         now: DateTime<Utc>,
     ) -> Result<(bool, Option<i64>, TokenAmount, TokenAmount)> {
-        let dripped_key = format!("dripped");
         let dripped: TokenAmount = self
             .state
             .storage()
-            .get(&dripped_key)
+            .get("dripped")
             .await
             .unwrap_or(TokenAmount::default());
         let claimed_key = format!("claimed_{id}");
@@ -57,11 +56,10 @@ impl RateLimiter {
             return Ok((false, Some(retry_after), claimed, dripped));
         }
 
-        let block_until_key = format!("block_until");
         let block_until = self
             .state
             .storage()
-            .get(&block_until_key)
+            .get("block_until")
             .await
             .map(|v| DateTime::<Utc>::from_timestamp(v, 0).unwrap_or_default())
             .unwrap_or(now);
@@ -91,7 +89,7 @@ impl RateLimiter {
 
         self.state
             .storage()
-            .put(&format!("dripped"), update_dripped.clone())
+            .put("dripped", update_dripped.clone())
             .await?;
         self.state
             .storage()
@@ -99,7 +97,7 @@ impl RateLimiter {
             .await?;
         self.state
             .storage()
-            .put(&format!("block_until"), next_block.timestamp())
+            .put("block_until", next_block.timestamp())
             .await?;
 
         if self.state.storage().get_alarm().await?.is_none() {

--- a/src/faucet/rate_limiter.rs
+++ b/src/faucet/rate_limiter.rs
@@ -351,7 +351,7 @@ mod tests {
         assert!(result.is_none());
     }
 
-    /// Checks that a request is rate limited if block_until is in the future (cooldown period).
+    /// Checks that a request is rate limited.
     #[tokio::test]
     async fn test_rate_limiter_cooldown_period() {
         let wallet_id = "test_wallet";
@@ -440,7 +440,7 @@ mod tests {
         assert!(result.is_none());
     }
 
-    /// Checks that parse_request_path correctly parses a valid path.
+    /// Checks path parsing with a valid path.
     #[tokio::test]
     async fn test_parse_request_path() {
         let path = "http://do/rate_limiter/CalibnetFIL/test_wallet_123";
@@ -450,7 +450,7 @@ mod tests {
         assert_eq!(id, "test_wallet_123");
     }
 
-    /// Checks that parse_request_path returns an error for an invalid faucet.
+    /// Checks path parsing with an invalid path.
     #[tokio::test]
     async fn test_parse_request_path_invalid_faucet() {
         let path = "http://do/rate_limiter/InvalidFaucet/test_wallet";
@@ -458,7 +458,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// Checks that the alarm handler calls delete_all on storage.
+    /// Checks that the alarm handler resets storage.
     #[tokio::test]
     async fn test_alarm_handler() {
         let mut mock_storage = MockRateLimiterStorage::new();
@@ -741,7 +741,7 @@ mod tests {
         assert!(result.is_none());
     }
 
-    /// Simulates the cooldown period: allowed, blocked, partially blocked, then allowed again.
+    /// Simulates the cool-down stages: allowed, blocked, partially blocked, then allowed again.
     #[tokio::test]
     async fn test_cooldown_period_progression() {
         let faucet_info = FaucetInfo::CalibnetFIL;

--- a/src/faucet/server.rs
+++ b/src/faucet/server.rs
@@ -88,7 +88,10 @@ pub async fn sign_with_eth_secret_key(
     .await
 }
 
-/// Internal. Queries the rate limiter Durable Object to check if the request can proceed.
+/// Queries the rate limiter for a specific faucet and wallet ID.
+/// Returns:
+/// - `None` if no rate limit is set.
+/// - `Some(i32)` containing the remaining cooldown time in seconds.
 pub async fn query_rate_limiter(
     faucet_info: FaucetInfo,
     id: u64,

--- a/src/faucet/server.rs
+++ b/src/faucet/server.rs
@@ -91,7 +91,7 @@ pub async fn sign_with_eth_secret_key(
 /// Queries the rate limiter for a specific faucet and wallet ID.
 /// Returns:
 /// - `None` if no rate limit is set.
-/// - `Some(i32)` containing the remaining cooldown time in seconds.
+/// - `Some(i32)` containing the remaining cool-down time in seconds.
 pub async fn query_rate_limiter(
     faucet_info: FaucetInfo,
     id: u64,

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -125,8 +125,7 @@ pub async fn signed_fil_transfer(
         gas_premium,
         sequence,
     );
-    let signed = sign_with_secret_key(unsigned_msg, faucet_info)
-        .await?;
+    let signed = sign_with_secret_key(unsigned_msg, faucet_info).await?;
     Ok(signed)
 }
 
@@ -148,7 +147,9 @@ pub async fn signed_erc20_transfer(
     use alloy::network::TransactionBuilder as _;
 
     let LotusJson(recipient) = recipient;
-    let id = recipient.id().map_err(|e| FaucetError::Server(e.to_string()))?;
+    let id = recipient
+        .id()
+        .map_err(|e| FaucetError::Server(e.to_string()))?;
     let rate_limit_seconds = check_rate_limit(faucet_info, id).await?;
     if let Some(secs) = rate_limit_seconds {
         return Err(FaucetError::RateLimited {
@@ -187,7 +188,6 @@ pub async fn signed_erc20_transfer(
         .with_gas_price(gas_price.into())
         .with_input(calldata);
 
-    let signed = sign_with_eth_secret_key(tx.clone(), faucet_info)
-        .await?;
+    let signed = sign_with_eth_secret_key(tx.clone(), faucet_info).await?;
     Ok(signed)
 }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -129,6 +129,7 @@ pub async fn signed_erc20_transfer(
     nonce: u64,
     gas_price: u64,
     faucet_info: FaucetInfo,
+    id: u64,
 ) -> Result<Vec<u8>, ServerFnError> {
     use crate::utils::conversions::TokenAmountAlloyExt as _;
     use alloy::network::TransactionBuilder as _;
@@ -162,5 +163,5 @@ pub async fn signed_erc20_transfer(
         .with_gas_price(gas_price.into())
         .with_input(calldata);
 
-    sign_with_eth_secret_key(tx.clone(), faucet_info).await
+    sign_with_eth_secret_key(tx.clone(), faucet_info, id).await
 }

--- a/src/faucet/views/components/faucet_description.rs
+++ b/src/faucet/views/components/faucet_description.rs
@@ -3,13 +3,7 @@ use crate::utils::format::format_balance;
 use leptos::prelude::*;
 use leptos::{component, view, IntoView};
 
-/// Displays descriptive information about the faucet.
-/// This component renders a user-friendly description of the faucet's token distribution
-/// rules and limitations, including:
-/// - The amount of tokens dispensed per drip
-/// - The token unit/symbol
-/// - Rate limiting information (time between requests)
-/// - Wallet capping
+/// This component renders a user-friendly description of the faucet's token distribution rules and limitations.
 #[component]
 pub fn FaucetDescription(faucet_info: FaucetInfo) -> impl IntoView {
     let drip_amount = faucet_info.drip_amount();

--- a/src/faucet/views/components/faucet_description.rs
+++ b/src/faucet/views/components/faucet_description.rs
@@ -1,28 +1,22 @@
+use crate::faucet::constants::FaucetInfo;
 use crate::utils::format::format_balance;
-use fvm_shared::econ::TokenAmount;
 use leptos::prelude::*;
 use leptos::{component, view, IntoView};
 
 #[component]
-pub fn FaucetDescription(
-    /// Amount of tokens to be dripped per request
-    drip_amount: TokenAmount,
-    /// Maximum amount of tokens a wallet can receive from the faucet
-    wallet_cap: TokenAmount,
-    /// Unit of the token (e.g., "FIL", "tFIL", "USDFC")
-    token_unit: String,
-    /// Time in seconds between allowed faucet requests
-    rate_limit_seconds: i64,
-    /// Time in seconds after which the wallet cap resets
-    wallet_limit_seconds: i64,
-) -> impl IntoView {
+pub fn FaucetDescription(faucet_info: FaucetInfo) -> impl IntoView {
+    let drip_amount = faucet_info.drip_amount();
+    let token_unit = faucet_info.unit();
+    let wallet_cap = faucet_info.wallet_cap();
+    let rate_limit_seconds = faucet_info.rate_limit_seconds();
+    let wallet_limit_seconds = faucet_info.wallet_limit_seconds();
     view! {
         <div class="description">
             <p>
-                "This faucet distributes " {format_balance(&drip_amount, &token_unit)}
+                "This faucet distributes " {format_balance(drip_amount, token_unit)}
                 " per request and is rate-limited to 1 request per " {rate_limit_seconds}
                 " seconds per address. Each wallet address is subject to receive "
-                {format_balance(&wallet_cap, &token_unit)} " every "{wallet_limit_seconds / 3600}
+                {format_balance(&wallet_cap, token_unit)} " every "{wallet_limit_seconds / 3600}
                 " hours, and exceeding this limit may result in temporary restrictions."
             </p>
             <p>

--- a/src/faucet/views/components/faucet_description.rs
+++ b/src/faucet/views/components/faucet_description.rs
@@ -3,6 +3,13 @@ use crate::utils::format::format_balance;
 use leptos::prelude::*;
 use leptos::{component, view, IntoView};
 
+/// Displays descriptive information about the faucet.
+/// This component renders a user-friendly description of the faucet's token distribution
+/// rules and limitations, including:
+/// - The amount of tokens dispensed per drip
+/// - The token unit/symbol
+/// - Rate limiting information (time between requests)
+/// - Wallet capping
 #[component]
 pub fn FaucetDescription(faucet_info: FaucetInfo) -> impl IntoView {
     let drip_amount = faucet_info.drip_amount();

--- a/src/faucet/views/components/faucet_description.rs
+++ b/src/faucet/views/components/faucet_description.rs
@@ -1,5 +1,6 @@
 use crate::faucet::constants::FaucetInfo;
 use crate::utils::format::format_balance;
+use chrono::Duration;
 use leptos::prelude::*;
 use leptos::{component, view, IntoView};
 
@@ -11,22 +12,21 @@ pub fn FaucetDescription(faucet_info: FaucetInfo) -> impl IntoView {
     let wallet_cap = faucet_info.wallet_cap();
     let drip_cap = faucet_info.drip_cap();
     let rate_limit_seconds = faucet_info.rate_limit_seconds();
-    let reset_limiter_seconds = faucet_info.reset_limiter_seconds();
+    let reset_limiter_hours = Duration::seconds(faucet_info.reset_limiter_seconds()).num_hours();
     view! {
         <div class="description">
             <p>
                 "This faucet distributes " {format_balance(drip_amount, token_unit)}
                 " per request and is rate-limited to 1 request per " {rate_limit_seconds}
                 " seconds. Each wallet address is subject to receive " {format_balance(&wallet_cap, token_unit)}
-                " every "{reset_limiter_seconds / 3600}
-                " hours, and exceeding this limit may result in temporary restrictions."
+                " every " {reset_limiter_hours} " hours, and exceeding this limit may result in temporary restrictions."
             </p>
             <p>
                 "Farming, abuse, or automated requests are strictly prohibited and will lead to stricter rate limits, temporary suspensions, or permanent bans."
             </p>
             <p>
                 "Faucet funds are limited, so there is a maximum distribution cap of "
-                {format_balance(&drip_cap, token_unit)} " for all users combined every " {reset_limiter_seconds / 3600}
+                {format_balance(&drip_cap, token_unit)} " for all users combined every " {reset_limiter_hours}
                 " hours. Refills are not guaranteed and occur periodically based on availability."
             </p>
         </div>

--- a/src/faucet/views/components/faucet_description.rs
+++ b/src/faucet/views/components/faucet_description.rs
@@ -9,22 +9,25 @@ pub fn FaucetDescription(faucet_info: FaucetInfo) -> impl IntoView {
     let drip_amount = faucet_info.drip_amount();
     let token_unit = faucet_info.unit();
     let wallet_cap = faucet_info.wallet_cap();
+    let drip_cap = faucet_info.drip_cap();
     let rate_limit_seconds = faucet_info.rate_limit_seconds();
-    let wallet_limit_seconds = faucet_info.wallet_limit_seconds();
+    let reset_limiter_seconds = faucet_info.reset_limiter_seconds();
     view! {
         <div class="description">
             <p>
                 "This faucet distributes " {format_balance(drip_amount, token_unit)}
                 " per request and is rate-limited to 1 request per " {rate_limit_seconds}
                 " seconds per address. Each wallet address is subject to receive "
-                {format_balance(&wallet_cap, token_unit)} " every "{wallet_limit_seconds / 3600}
+                {format_balance(&wallet_cap, token_unit)} " every "{reset_limiter_seconds / 3600}
                 " hours, and exceeding this limit may result in temporary restrictions."
             </p>
             <p>
                 "Farming, abuse, or automated requests are strictly prohibited and will lead to stricter rate limits, temporary suspensions, or permanent bans."
             </p>
             <p>
-                "Faucet funds are limited and may run out. Refills are not guaranteed and occur periodically based on availability."
+                "Faucet funds are limited, so there is a maximum distribution cap of "
+                {format_balance(&drip_cap, token_unit)} " for all users combined every " {reset_limiter_seconds / 3600}
+                " hours. Refills are not guaranteed and occur periodically based on availability."
             </p>
         </div>
     }

--- a/src/faucet/views/components/faucet_description.rs
+++ b/src/faucet/views/components/faucet_description.rs
@@ -17,8 +17,8 @@ pub fn FaucetDescription(faucet_info: FaucetInfo) -> impl IntoView {
             <p>
                 "This faucet distributes " {format_balance(drip_amount, token_unit)}
                 " per request and is rate-limited to 1 request per " {rate_limit_seconds}
-                " seconds per address. Each wallet address is subject to receive "
-                {format_balance(&wallet_cap, token_unit)} " every "{reset_limiter_seconds / 3600}
+                " seconds. Each wallet address is subject to receive " {format_balance(&wallet_cap, token_unit)}
+                " every "{reset_limiter_seconds / 3600}
                 " hours, and exceeding this limit may result in temporary restrictions."
             </p>
             <p>

--- a/src/faucet/views/components/faucet_description.rs
+++ b/src/faucet/views/components/faucet_description.rs
@@ -5,16 +5,25 @@ use leptos::{component, view, IntoView};
 
 #[component]
 pub fn FaucetDescription(
+    /// Amount of tokens to be dripped per request
     drip_amount: TokenAmount,
+    /// Maximum amount of tokens a wallet can receive from the faucet
+    wallet_cap: TokenAmount,
+    /// Unit of the token (e.g., "FIL", "tFIL", "USDFC")
     token_unit: String,
+    /// Time in seconds between allowed faucet requests
     rate_limit_seconds: i64,
+    /// Time in seconds after which the wallet cap resets
+    wallet_limit_seconds: i64,
 ) -> impl IntoView {
     view! {
         <div class="description">
             <p>
                 "This faucet distributes " {format_balance(&drip_amount, &token_unit)}
-                " per request and is rate-limited to one request per " {rate_limit_seconds}
-                " seconds per address. Each wallet address is subject to a daily cap, and exceeding this limit may result in temporary restrictions."
+                " per request and is rate-limited to 1 request per " {rate_limit_seconds}
+                " seconds per address. Each wallet address is subject to receive "
+                {format_balance(&wallet_cap, &token_unit)} " every "{wallet_limit_seconds / 3600}
+                " hours, and exceeding this limit may result in temporary restrictions."
             </p>
             <p>
                 "Farming, abuse, or automated requests are strictly prohibited and will lead to stricter rate limits, temporary suspensions, or permanent bans."

--- a/src/faucet/views/faucets/calibnet.rs
+++ b/src/faucet/views/faucets/calibnet.rs
@@ -11,7 +11,9 @@ pub fn Faucet_Calibnet() -> impl IntoView {
     let drip_amount = FaucetInfo::CalibnetFIL.drip_amount();
     let token_unit = FaucetInfo::CalibnetFIL.unit();
     let rate_limit_seconds = FaucetInfo::CalibnetFIL.rate_limit_seconds();
+    let wallet_cap = FaucetInfo::CalibnetFIL.wallet_cap();
     let rpc_context = RpcContext::use_context();
+    let wallet_limit_seconds = FaucetInfo::CalibnetFIL.wallet_limit_seconds();
     // Set rpc context to calibnet url
     rpc_context.set(Provider::get_network_url(FaucetInfo::CalibnetFIL.network()));
 
@@ -26,8 +28,10 @@ pub fn Faucet_Calibnet() -> impl IntoView {
             <Faucet faucet_info=FaucetInfo::CalibnetFIL />
             <FaucetDescription
                 drip_amount=drip_amount.clone()
+                wallet_cap=wallet_cap
                 token_unit=token_unit.to_string()
                 rate_limit_seconds=rate_limit_seconds
+                wallet_limit_seconds=wallet_limit_seconds
             />
         </div>
     }

--- a/src/faucet/views/faucets/calibnet.rs
+++ b/src/faucet/views/faucets/calibnet.rs
@@ -8,12 +8,8 @@ use leptos_meta::{Meta, Title};
 
 #[component]
 pub fn Faucet_Calibnet() -> impl IntoView {
-    let drip_amount = FaucetInfo::CalibnetFIL.drip_amount();
-    let token_unit = FaucetInfo::CalibnetFIL.unit();
-    let rate_limit_seconds = FaucetInfo::CalibnetFIL.rate_limit_seconds();
-    let wallet_cap = FaucetInfo::CalibnetFIL.wallet_cap();
+    let faucet_info = FaucetInfo::CalibnetFIL;
     let rpc_context = RpcContext::use_context();
-    let wallet_limit_seconds = FaucetInfo::CalibnetFIL.wallet_limit_seconds();
     // Set rpc context to calibnet url
     rpc_context.set(Provider::get_network_url(FaucetInfo::CalibnetFIL.network()));
 
@@ -25,14 +21,8 @@ pub fn Faucet_Calibnet() -> impl IntoView {
         />
         <h1 class="header">"🧪 Filecoin Calibnet Faucet"</h1>
         <div class="main-container">
-            <Faucet faucet_info=FaucetInfo::CalibnetFIL />
-            <FaucetDescription
-                drip_amount=drip_amount.clone()
-                wallet_cap=wallet_cap
-                token_unit=token_unit.to_string()
-                rate_limit_seconds=rate_limit_seconds
-                wallet_limit_seconds=wallet_limit_seconds
-            />
+            <Faucet faucet_info=faucet_info />
+            <FaucetDescription faucet_info=faucet_info />
         </div>
     }
 }

--- a/src/faucet/views/faucets/calibnet.rs
+++ b/src/faucet/views/faucets/calibnet.rs
@@ -6,6 +6,8 @@ use leptos::prelude::*;
 use leptos::{component, view, IntoView};
 use leptos_meta::{Meta, Title};
 
+/// Displays the Calibnet Faucet page.
+/// Sets the RPC context to calibnet and renders the faucet and its description.
 #[component]
 pub fn Faucet_Calibnet() -> impl IntoView {
     let faucet_info = FaucetInfo::CalibnetFIL;

--- a/src/faucet/views/faucets/calibnet_usdfc.rs
+++ b/src/faucet/views/faucets/calibnet_usdfc.rs
@@ -6,6 +6,8 @@ use leptos::prelude::*;
 use leptos::{component, view, IntoView};
 use leptos_meta::{Meta, Title};
 
+/// Displays the Calibnet USDFC Faucet page.
+/// Sets the RPC context to calibnet USDFC and renders the faucet and its description.
 #[component]
 pub fn Faucet_Calibnet_USDFC() -> impl IntoView {
     let faucet_info = FaucetInfo::CalibnetUSDFC;

--- a/src/faucet/views/faucets/calibnet_usdfc.rs
+++ b/src/faucet/views/faucets/calibnet_usdfc.rs
@@ -1,6 +1,6 @@
 use super::Faucet;
 use crate::faucet::constants::FaucetInfo;
-use crate::utils::format::format_balance;
+use crate::faucet::views::components::faucet_description::FaucetDescription;
 use crate::utils::rpc_context::{Provider, RpcContext};
 use leptos::prelude::*;
 use leptos::{component, view, IntoView};
@@ -8,12 +8,8 @@ use leptos_meta::{Meta, Title};
 
 #[component]
 pub fn Faucet_Calibnet_USDFC() -> impl IntoView {
-    let drip_amount = FaucetInfo::CalibnetUSDFC.drip_amount();
-    let token_unit = FaucetInfo::CalibnetUSDFC.unit();
-    let rate_limit_seconds = FaucetInfo::CalibnetUSDFC.rate_limit_seconds();
-    let wallet_cap = FaucetInfo::CalibnetUSDFC.wallet_cap();
+    let faucet_info = FaucetInfo::CalibnetUSDFC;
     let rpc_context = RpcContext::use_context();
-    let wallet_limit_seconds = FaucetInfo::CalibnetUSDFC.wallet_limit_seconds();
     rpc_context.set(Provider::get_network_url(
         FaucetInfo::CalibnetUSDFC.network(),
     ));
@@ -26,19 +22,8 @@ pub fn Faucet_Calibnet_USDFC() -> impl IntoView {
         />
         <h1 class="header">"💰 Filecoin Calibnet USDFC Faucet"</h1>
         <div class="main-container">
-            <Faucet faucet_info=FaucetInfo::CalibnetUSDFC />
-            <div class="description">
-                <p>
-                    "This faucet distributes " {format_balance(drip_amount, token_unit)}
-                    " per request. It is rate-limited to 1 request per " {rate_limit_seconds}
-                    " seconds. Each wallet address is subject to receive " {format_balance(&wallet_cap, token_unit)}
-                    " every " {wallet_limit_seconds / 3600}
-                    " hours, and exceeding this limit may result in temporary restrictions."
-                </p>
-                <p>
-                    "Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
-                </p>
-            </div>
+            <Faucet faucet_info=faucet_info />
+            <FaucetDescription faucet_info=faucet_info />
             <div class="description">
                 <p>
                     "You can also obtain testnet USDFC by minting it and using tFIL as collateral with the "

--- a/src/faucet/views/faucets/calibnet_usdfc.rs
+++ b/src/faucet/views/faucets/calibnet_usdfc.rs
@@ -11,7 +11,9 @@ pub fn Faucet_Calibnet_USDFC() -> impl IntoView {
     let drip_amount = FaucetInfo::CalibnetUSDFC.drip_amount();
     let token_unit = FaucetInfo::CalibnetUSDFC.unit();
     let rate_limit_seconds = FaucetInfo::CalibnetUSDFC.rate_limit_seconds();
+    let wallet_cap = FaucetInfo::CalibnetUSDFC.wallet_cap();
     let rpc_context = RpcContext::use_context();
+    let wallet_limit_seconds = FaucetInfo::CalibnetUSDFC.wallet_limit_seconds();
     rpc_context.set(Provider::get_network_url(
         FaucetInfo::CalibnetUSDFC.network(),
     ));
@@ -26,9 +28,16 @@ pub fn Faucet_Calibnet_USDFC() -> impl IntoView {
         <div class="main-container">
             <Faucet faucet_info=FaucetInfo::CalibnetUSDFC />
             <div class="description">
-                "This faucet distributes " {format_balance(drip_amount, token_unit)}
-                " per request. It is rate-limited to 1 request per " {rate_limit_seconds}
-                " seconds. Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
+                <p>
+                    "This faucet distributes " {format_balance(drip_amount, token_unit)}
+                    " per request. It is rate-limited to 1 request per " {rate_limit_seconds}
+                    " seconds. Each wallet address is subject to receive " {format_balance(&wallet_cap, token_unit)}
+                    " every " {wallet_limit_seconds / 3600}
+                    " hours, and exceeding this limit may result in temporary restrictions."
+                </p>
+                <p>
+                    "Farming is discouraged and will result in more stringent rate limiting in the future and/or permanent bans."
+                </p>
             </div>
             <div class="description">
                 <p>

--- a/src/faucet/views/faucets/mainnet.rs
+++ b/src/faucet/views/faucets/mainnet.rs
@@ -11,7 +11,9 @@ pub fn Faucet_Mainnet() -> impl IntoView {
     let drip_amount = FaucetInfo::MainnetFIL.drip_amount();
     let token_unit = FaucetInfo::MainnetFIL.unit();
     let rate_limit_seconds = FaucetInfo::MainnetFIL.rate_limit_seconds();
+    let wallet_cap = FaucetInfo::MainnetFIL.wallet_cap();
     let rpc_context = RpcContext::use_context();
+    let wallet_limit_seconds = FaucetInfo::MainnetFIL.wallet_limit_seconds();
     // Set rpc context to mainnet url
     rpc_context.set(Provider::get_network_url(FaucetInfo::MainnetFIL.network()));
 
@@ -24,8 +26,10 @@ pub fn Faucet_Mainnet() -> impl IntoView {
             <Faucet faucet_info=FaucetInfo::MainnetFIL />
             <FaucetDescription
                 drip_amount=drip_amount.clone()
+                wallet_cap=wallet_cap
                 token_unit=token_unit.to_string()
                 rate_limit_seconds=rate_limit_seconds
+                wallet_limit_seconds=wallet_limit_seconds
             />
         </div>
     }

--- a/src/faucet/views/faucets/mainnet.rs
+++ b/src/faucet/views/faucets/mainnet.rs
@@ -6,6 +6,8 @@ use leptos::prelude::*;
 use leptos::{component, view, IntoView};
 use leptos_meta::{Meta, Title};
 
+/// Displays the Mainnet Faucet page.
+/// Sets the RPC context to mainnet and renders the faucet and its description.
 #[component]
 pub fn Faucet_Mainnet() -> impl IntoView {
     let faucet_info = FaucetInfo::MainnetFIL;

--- a/src/faucet/views/faucets/mainnet.rs
+++ b/src/faucet/views/faucets/mainnet.rs
@@ -8,12 +8,8 @@ use leptos_meta::{Meta, Title};
 
 #[component]
 pub fn Faucet_Mainnet() -> impl IntoView {
-    let drip_amount = FaucetInfo::MainnetFIL.drip_amount();
-    let token_unit = FaucetInfo::MainnetFIL.unit();
-    let rate_limit_seconds = FaucetInfo::MainnetFIL.rate_limit_seconds();
-    let wallet_cap = FaucetInfo::MainnetFIL.wallet_cap();
+    let faucet_info = FaucetInfo::MainnetFIL;
     let rpc_context = RpcContext::use_context();
-    let wallet_limit_seconds = FaucetInfo::MainnetFIL.wallet_limit_seconds();
     // Set rpc context to mainnet url
     rpc_context.set(Provider::get_network_url(FaucetInfo::MainnetFIL.network()));
 
@@ -23,14 +19,8 @@ pub fn Faucet_Mainnet() -> impl IntoView {
 
         <h1 class="header">"🌐 Filecoin Mainnet Faucet"</h1>
         <div class="main-container">
-            <Faucet faucet_info=FaucetInfo::MainnetFIL />
-            <FaucetDescription
-                drip_amount=drip_amount.clone()
-                wallet_cap=wallet_cap
-                token_unit=token_unit.to_string()
-                rate_limit_seconds=rate_limit_seconds
-                wallet_limit_seconds=wallet_limit_seconds
-            />
+            <Faucet faucet_info=faucet_info />
+            <FaucetDescription faucet_info=faucet_info />
         </div>
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,6 @@ mod ssr_imports {
         server_fn::axum::register_explicit::<faucet::server_api::SignedFilTransfer>();
         server_fn::axum::register_explicit::<faucet::server_api::SignedErc20Transfer>();
         server_fn::axum::register_explicit::<faucet::server_api::FaucetAddress>();
-        server_fn::axum::register_explicit::<faucet::server_api::CheckRateLimit>();
     }
 
     #[event(fetch)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod ssr_imports {
         server_fn::axum::register_explicit::<faucet::server_api::SignedFilTransfer>();
         server_fn::axum::register_explicit::<faucet::server_api::SignedErc20Transfer>();
         server_fn::axum::register_explicit::<faucet::server_api::FaucetAddress>();
+        server_fn::axum::register_explicit::<faucet::server_api::CheckRateLimit>();
     }
 
     #[event(fetch)]

--- a/src/utils/address.rs
+++ b/src/utils/address.rs
@@ -251,6 +251,16 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_id_address() {
+        let addr = Address::new_id(163506);
+        let eth_addr = addr.into_eth_address().unwrap();
+        let exp_addr =
+            parse_address(&eth_addr.to_string().to_lowercase(), Network::Mainnet).unwrap();
+
+        assert_eq!(addr, exp_addr);
+    }
+
+    #[test]
     fn test_id_address_conversion_to_eth() {
         let address = Address::new_id(163506);
         let eth_addr = address.into_eth_address().unwrap();

--- a/src/utils/address.rs
+++ b/src/utils/address.rs
@@ -60,9 +60,13 @@ pub fn parse_address(raw: &str, n: Network) -> anyhow::Result<Address> {
             s.chars().skip(2).all(|c| c.is_ascii_hexdigit()),
             "Invalid characters in address"
         );
-
-        let addr = hex::decode(&s[2..])?;
-        Ok(Address::new_delegated(EAM_NAMESPACE, &addr)?)
+        if let Some(id) = s.strip_prefix("0xff") {
+            let id = u64::from_str_radix(id, 16)?;
+            Ok(Address::new_id(id))
+        } else {
+            let addr = hex::decode(&s[2..])?;
+            Ok(Address::new_delegated(EAM_NAMESPACE, &addr)?)
+        }
     } else {
         Ok(n.parse_address(&s)?)
     }

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -1,6 +1,35 @@
-use leptos::prelude::{RwSignal, Update};
+use leptos::prelude::{RwSignal, ServerFnError, Update};
+use leptos::server_fn::codec::JsonEncoding;
+use leptos::server_fn::error::{FromServerFnError, ServerFnErrorErr};
+use serde::{Deserialize, Serialize};
 use std::future::Future;
+use thiserror::Error;
 use uuid::Uuid;
+
+/// This enum represents all possible errors that can occur in the faucet system,
+/// including rate limiting and other server errors.
+#[derive(Debug, Error, Clone, Serialize, Deserialize)]
+pub enum FaucetError {
+    /// Returned when a request is rate limited. Contains the number of seconds to wait before retrying.
+    #[error("Rate limited. Try again in {retry_after_secs} seconds.")]
+    RateLimited { retry_after_secs: i32 },
+    /// Represents a server-side error with a message.
+    #[error("Server error: {0}")]
+    Server(String),
+}
+
+impl FromServerFnError for FaucetError {
+    type Encoder = JsonEncoding;
+    fn from_server_fn_error(err: ServerFnErrorErr) -> Self {
+        FaucetError::Server(err.to_string())
+    }
+}
+
+impl From<ServerFnError> for FaucetError {
+    fn from(e: leptos::prelude::ServerFnError) -> Self {
+        FaucetError::Server(e.to_string())
+    }
+}
 
 pub async fn catch_all(
     errors: RwSignal<Vec<(Uuid, String)>>,

--- a/src/utils/rpc_context.rs
+++ b/src/utils/rpc_context.rs
@@ -223,6 +223,18 @@ impl Provider {
         .await
     }
 
+    /// Looks up the ID address of a given Filecoin address.
+    /// This method makes an RPC call to the Filecoin node to convert a Filecoin address
+    /// to its corresponding ID address in the current state tree.
+    pub async fn lookup_id(&self, addr: Address) -> anyhow::Result<Address> {
+        invoke_rpc_method(
+            &self.url,
+            "Filecoin.StateLookupID",
+            &[serde_json::to_value(LotusJson(addr))?, Value::Null],
+        )
+        .await
+    }
+
     /// Returns the current gas price in attoFIL.
     ///
     /// Internally, it prunes the result from `u128` to `u64` but it should be safe as we don't


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Added per wallet daily cap on token claim.
- Wallet cap is set to 1x of drip amount for mainnet and 2x for calibnet.
- Drip cap is set for 2x of drip amount for mainnet and 5x for calibnet, combined across all users.
- Capping resets every 24hrs.
- All address formats are normalised to ID address.
- Fixed: Show correct wait in secs when rate limited (also works on page refresh).
- Added rate limiter test

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #257 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced per-wallet daily caps and global distribution caps for faucet token claims.
  * Enhanced rate limiting with cooldowns, wallet caps, and global caps, now providing users with retry-after information if rate limited.
  * Faucet descriptions now display detailed information about drip amounts, rate limits, wallet caps, and global caps.
  * Added support for parsing Ethereum-style addresses as Filecoin ID addresses.

* **Bug Fixes**
  * Improved address parsing to handle special Ethereum address formats.

* **Refactor**
  * Streamlined faucet components to use consolidated faucet information.
  * Modularized and abstracted rate limiting logic for better maintainability.

* **Documentation**
  * Updated changelog and added doc comments to faucet components.

* **Chores**
  * Added new dependencies for error handling and testing.
  * Improved and expanded unit test coverage for rate limiting and address parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->