### PR TITLE
chore: remove some misleading/redundant docs

### DIFF
--- a/src/faucet/constants.rs
+++ b/src/faucet/constants.rs
@@ -4,27 +4,23 @@ use serde::{Deserialize, Serialize};
 use std::{str::FromStr as _, sync::LazyLock};
 use strum::EnumString;
 
-/// The amount of mainnet FIL to be dripped to the user. This corresponds to 1 tFIL.
+/// The amount of mainnet FIL to be dripped to the user.
 static CALIBNET_DRIP_AMOUNT: LazyLock<TokenAmount> = LazyLock::new(|| TokenAmount::from_whole(1));
 
 /// The amount of mainnet FIL to be dripped to the user. This corresponds to 0.01 FIL.
 static MAINNET_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_nano(10_000_000));
 
-/// The amount of calibnet `USDFC` to be dripped to the user. This corresponds to 1 `tUSDFC`.
+/// The amount of calibnet `USDFC` to be dripped to the user.
 static CALIBNET_USDFC_DRIP_AMOUNT: LazyLock<TokenAmount> =
     LazyLock::new(|| TokenAmount::from_whole(5));
 
 /// Multiplier to determine the maximum amount of tokens that can be dripped per wallet every [`FaucetInfo::reset_limiter_seconds`].
-/// This corresponds to 1 * [`FaucetInfo::drip_amount`]
 const MAINNET_PER_WALLET_DRIP_MULTIPLIER: i64 = 1;
-/// This corresponds to 2 * [`FaucetInfo::drip_amount`]
 const CALIBNET_PER_WALLET_DRIP_MULTIPLIER: i64 = 2;
 
 /// Multiplier used to determine the maximum amount of tokens that can be dripped globally every [`FaucetInfo::reset_limiter_seconds`].
-/// This corresponds to 2 * [`FaucetInfo::drip_amount`]
 const MAINNET_GLOBAL_DRIP_MULTIPLIER: i64 = 2;
-/// This corresponds to 5 * [`FaucetInfo::drip_amount`]
 const CALIBNET_GLOBAL_DRIP_MULTIPLIER: i64 = 200;
 
 /// Cool-down duration in seconds between faucet requests on mainnet.
@@ -182,7 +178,7 @@ impl FaucetInfo {
     pub fn chain_id(&self) -> u64 {
         match self.network() {
             Network::Mainnet => 314,    // https://chainlist.org/chain/314
-            Network::Testnet => 314159, // chainlist.org/chain/314159
+            Network::Testnet => 314159, // https://chainlist.org/chain/314159
         }
     }
 

--- a/src/faucet/constants.rs
+++ b/src/faucet/constants.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::{str::FromStr as _, sync::LazyLock};
 use strum::EnumString;
 
-/// The amount of mainnet FIL to be dripped to the user.
+/// The amount of calibnet FIL to be dripped to the user.
 static CALIBNET_DRIP_AMOUNT: LazyLock<TokenAmount> = LazyLock::new(|| TokenAmount::from_whole(1));
 
 /// The amount of mainnet FIL to be dripped to the user. This corresponds to 0.01 FIL.


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- removed some misleading or redundant docs
- follow-up of https://github.com/ChainSafe/forest-explorer/pull/311#discussion_r2375258816

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [x] I have performed a self-review of my own code,
- [x] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [x] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [x] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified faucet drip amount descriptions to be less technical and updated Testnet reference link for clarity.
  * Confirmed no user-visible changes to drip amounts or limits.

* **Chores**
  * Removed outdated internal multiplier references to simplify internal configuration (no impact on public behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->