### PR TITLE
API to request calibnet drip tFIL and tUSDFC

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,4 +84,4 @@ jobs:
           path: 'e2e/test_claim_token_api.js'
         env:
           BASE_URL: 'http://127.0.0.1:8787'
-          FAUCET_TX_URL_CALIBNET: ${{ env.FAUCET_TX_URL_CALIBNET }}
+          CALIBNET_RPC: 'https://api.calibration.node.glif.io/rpc/v1'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,3 +77,11 @@ jobs:
         uses: grafana/run-k6-action@v1
         with:
           path: 'e2e/script.js'
+
+      - name: Run k6 test claim token api
+        uses: grafana/run-k6-action@v1
+        with:
+          path: 'e2e/test_claim_token_api.js'
+        env:
+          BASE_URL: 'http://127.0.0.1:8787'
+          FAUCET_TX_URL_CALIBNET: ${{ env.FAUCET_TX_URL_CALIBNET }}

--- a/e2e/script.js
+++ b/e2e/script.js
@@ -239,3 +239,4 @@ export default async function () {
     await page.close();
   }
 }
+

--- a/e2e/test_claim_token_api.js
+++ b/e2e/test_claim_token_api.js
@@ -1,0 +1,343 @@
+// k6 Faucet API Testing Script
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Rate } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://127.0.0.1:8787';
+const API_ENDPOINT = `${BASE_URL}/api/claim_token`;
+const CALIBNET_RPC = __ENV.FAUCET_TX_URL_CALIBNET || 'https://api.calibration.node.glif.io';
+
+const TEST_ADDRESSES = {
+  FIL_FORMAT_ADDRESS: 't1pxxbe7he3c6vcw5as3gfvq33kprpmlufgtjgfdq',
+  ETH_FORMAT_ADDRESS: '0xAe9C4b9508c929966ef37209b336E5796D632CDc',
+  INVALID_ADDRESS: 'invalid_address_123',
+  MAINNET_ADDRESS: 'f1mwllxrw7frn2lwhf4u26y4f3m7f6wsl4i3o3jvi',
+};
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  maxDuration: '6m',
+  thresholds: {
+    'checks': ['rate==1.0'],
+    'test_run_success_rate': ['rate==1.0'],
+  },
+};
+
+const testRunSuccessRate = new Rate('test_run_success_rate');
+
+const API_TESTS = [
+  {
+    name: 'Invalid Faucet Type',
+    data: `faucet_info=InvalidFaucet&address=${TEST_ADDRESSES.FIL_FORMAT_ADDRESS}`,
+    expectPattern: 'unknown variant',
+    expectSuccess: false,
+    verifyOnChain: false,
+  },
+  {
+    name: 'Typo in Faucet Type',
+    data: `faucet_info=CalibnettFIL&address=${TEST_ADDRESSES.FIL_FORMAT_ADDRESS}`,
+    expectPattern: 'unknown variant',
+    expectSuccess: false,
+    verifyOnChain: false,
+  },
+  {
+    name: 'Invalid Address Format',
+    data: `faucet_info=CalibnetFIL&address=${TEST_ADDRESSES.INVALID_ADDRESS}`,
+    expectPattern: 'ServerError|Not a valid Testnet address',
+    expectSuccess: false,
+    verifyOnChain: false,
+  },
+  {
+    name: 'Empty Address',
+    data: 'faucet_info=CalibnetFIL&address=',
+    expectPattern: 'ServerError|Not a valid Testnet address',
+    expectSuccess: false,
+    verifyOnChain: false,
+  },
+  {
+    name: 'Missing Address Parameter',
+    data: 'faucet_info=CalibnetFIL',
+    expectPattern: 'Args|missing field',
+    expectSuccess: false,
+    verifyOnChain: false,
+  },
+  {
+    name: 'Missing Faucet Info Parameter',
+    data: `address=${TEST_ADDRESSES.FIL_FORMAT_ADDRESS}`,
+    expectPattern: 'Args|missing field',
+    expectSuccess: false,
+    verifyOnChain: false,
+  },
+  {
+    name: 'Mainnet FIL Request (Security) - invalid address for testnet',
+    data: `faucet_info=CalibnetFIL&address=${TEST_ADDRESSES.MAINNET_ADDRESS}`,
+    expectPattern: 'ServerError|Not a valid Testnet address',
+    expectSuccess: false,
+    verifyOnChain: false,
+  },
+  {
+    name: 'Mainnet FIL Request (Security) - invalid faucet type',
+    data: `faucet_info=MainnetFIL&address=${TEST_ADDRESSES.FIL_FORMAT_ADDRESS}`,
+    expectPattern: 'ServerError|Mainnet',
+  },
+];
+
+const RATE_LIMIT_TESTS = [
+  {
+    name: 'Rate Limit Test: CalibnetFIL First Request (t1 format) - should succeed',
+    data: `faucet_info=CalibnetFIL&address=${TEST_ADDRESSES.FIL_FORMAT_ADDRESS}`,
+    expectSuccess: true,
+    verifyOnChain: true,
+    waitTime: 2,
+  },
+  {
+    name: 'Rate Limit Test: CalibnetFIL Consecutive Request (t1 format) - should be rate limited',
+    data: `faucet_info=CalibnetFIL&address=${TEST_ADDRESSES.FIL_FORMAT_ADDRESS}`,
+    expectPattern: 'ServerError|Rate limited. Try again',
+    verifyOnChain: false,
+    waitTime: 62,
+  },
+  {
+    name: 'Rate Limit Test: CalibnetFIL First Request (0x format) - should succeed',
+    data: `faucet_info=CalibnetFIL&address=${TEST_ADDRESSES.ETH_FORMAT_ADDRESS}`,
+    expectSuccess: true,
+    verifyOnChain: true,
+    waitTime: 2,
+  },
+  {
+    name: 'Rate Limit Test: CalibnetFIL Consecutive Request (0x format) - should be rate limited',
+    data: `faucet_info=CalibnetFIL&address=${TEST_ADDRESSES.ETH_FORMAT_ADDRESS}`,
+    expectPattern: 'ServerError|Rate limited.',
+    expectSuccess: false,
+    verifyOnChain: false,
+    waitTime: 62,
+  },
+  {
+    name: 'Rate Limit Test: CalibnetUSDFC First Request (0x format) - should succeed',
+    data: `faucet_info=CalibnetUSDFC&address=${TEST_ADDRESSES.ETH_FORMAT_ADDRESS}`,
+    expectSuccess: true,
+    verifyOnChain: true,
+    waitTime: 2,
+  },
+  {
+    name: 'Rate Limit Test: CalibnetUSDFC Consecutive Request (0x format) - should be rate limited',
+    data: `faucet_info=CalibnetUSDFC&address=${TEST_ADDRESSES.ETH_FORMAT_ADDRESS}`,
+    expectPattern: 'ServerError|Rate limited. Try again ',
+    expectSuccess: false,
+    verifyOnChain: false,
+    waitTime: 2,
+  },
+];
+
+function extractTransactionId(responseBody) {
+  const cleanResponse = responseBody.replace(/"/g, '').replace(/%$/, '').trim();
+
+  if (cleanResponse.length < 10) {
+    return null;
+  }
+
+  if (cleanResponse.startsWith('0x')) {
+    return { type: 'ethereum', id: cleanResponse };
+  }
+  return { type: 'filecoin', id: cleanResponse };
+}
+
+function verifyFilecoinTransaction(cid) {
+  const rpcRequest = {
+    jsonrpc: '2.0',
+    method: 'Filecoin.StateSearchMsg',
+    params: [null, { '/': cid }, 10, false],
+    id: 0,
+  };
+
+  const params = {
+    headers: { 'Content-Type': 'application/json' },
+  };
+
+  try {
+    const res = http.post(CALIBNET_RPC, JSON.stringify(rpcRequest), params);
+
+    if (res.status !== 200) {
+      console.error(`   RPC Error: ${res.status} - ${res.body}`);
+      return 'failed';
+    }
+
+    const result = res.json();
+    if (result.result === null) {
+      console.log(`   🟡 Transaction not yet confirmed (CID: ${cid})`);
+      return 'pending';
+    }
+
+    if (result.result) {
+      return 'confirmed';
+    }
+  } catch (e) {
+    console.error(`   Transaction verification failed: ${e.message}`);
+    return 'failed';
+  }
+  return 'failed';
+}
+
+function verifyEthereumTransaction(txHash) {
+  const rpcRequest = {
+    jsonrpc: '2.0',
+    method: 'eth_getTransactionReceipt',
+    params: [txHash],
+    id: 0,
+  };
+
+  const params = {
+    headers: { 'Content-Type': 'application/json' },
+  };
+
+  try {
+    const res = http.post(CALIBNET_RPC, JSON.stringify(rpcRequest), params);
+
+    if (res.status !== 200) {
+      console.error(`   RPC Error: ${res.status} - ${res.body}`);
+      return 'failed';
+    }
+
+    const result = res.json();
+    if (result.result === null) {
+      console.log(`   🟡 Transaction not yet confirmed (TX: ${txHash})`);
+      return 'pending';
+    }
+
+    if (result.result && result.result.blockNumber && result.result.status === '0x1') {
+      return 'confirmed';
+    } else if (result.result && result.result.blockNumber && result.result.status === '0x0') {
+      console.error(`   Transaction failed on-chain (TX: ${txHash})`);
+      return 'failed';
+    }
+  } catch (e) {
+    console.error(`   Transaction verification failed: ${e.message}`);
+    return 'failed';
+  }
+  return 'failed';
+}
+
+function verifyTransaction(transaction) {
+  if (transaction.type === 'filecoin') {
+    return verifyFilecoinTransaction(transaction.id);
+  } else if (transaction.type === 'ethereum') {
+    return verifyEthereumTransaction(transaction.id);
+  } else {
+    console.error(`   Unknown transaction type: ${transaction.type}`);
+    return 'failed';
+  }
+}
+
+function runTestSuite(tests, suiteName) {
+  console.log(`\n🧪 Starting ${suiteName}...`);
+
+  for (const test of tests) {
+    group(`🧪 ${test.name}`, () => {
+      console.log(`Running: ${test.name}`);
+
+      const params = {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      };
+
+      console.log(`   Request: ${test.data}`);
+      const res = http.post(API_ENDPOINT, test.data, params);
+      console.log(`   Response: ${res.body}`);
+
+      let testPassed = false;
+
+      if (test.expectSuccess) {
+        const isSuccess = check(res, {
+          'API call successful (status 200)': (r) => r.status === 200,
+        });
+
+        if (isSuccess) {
+          const transactionId = extractTransactionId(res.body);
+          const hasTxId = check(transactionId, {
+            'Response contains a valid transaction ID': (id) => id !== null,
+          });
+
+          if (hasTxId) {
+            console.log(`   📋 Transaction ID: ${transactionId.id} (${transactionId.type})`);
+
+            if (test.verifyOnChain) {
+              console.log(`   🔍 Verifying transaction on ${transactionId.type} network...`);
+              const verificationResult = verifyTransaction(transactionId);
+
+              const isVerified = check(verificationResult, {
+                'On-chain verification is confirmed or pending': (v) => v === 'confirmed' || v === 'pending',
+              });
+
+              if (verificationResult === 'pending') {
+                console.log(`   🟡 Transaction submitted successfully (pending confirmation)`);
+                console.log('   ✅ PASS: Transaction submitted successfully');
+              } else if (verificationResult === 'confirmed') {
+                console.log(`   ✅ On-chain verification: CONFIRMED`);
+                console.log('   ✅ PASS: Transaction confirmed on-chain');
+              } else {
+                console.log(`   ❌ On-chain verification: FAILED`);
+                console.log('   ❌ FAIL: Transaction verification failed');
+              }
+
+              testPassed = isVerified;
+            } else {
+              testPassed = hasTxId;
+              console.log('   ✅ PASS: Valid transaction ID returned');
+            }
+          } else {
+            console.log(`   ❌ FAIL: No valid transaction ID found in response`);
+          }
+        } else {
+          // API call failed when we expected success
+          console.log(`   ❌ FAIL: Expected success but API call failed (status ${res.status}): ${res.body}`);
+          testPassed = false;
+        }
+      } else {
+        // This is an expected failure case
+        const patternRegex = new RegExp(test.expectPattern);
+        testPassed = check(res, {
+          [`Response body contains expected error pattern "${test.expectPattern}"`]: (r) => patternRegex.test(r.body),
+        });
+
+        if (!testPassed) {
+          console.log(`   ❌ FAIL: Expected pattern "${test.expectPattern}", got: "${res.body}"`);
+        } else {
+          console.log(`   ✅ PASS: Found expected error pattern "${test.expectPattern}"`);
+        }
+      }
+
+      testRunSuccessRate.add(testPassed);
+    });
+
+    const waitTime = test.waitTime || 0.1;
+    if (waitTime > 1) {
+      console.log(`   ⏰ Waiting ${waitTime} seconds before next test (rate limiting)...`);
+    }
+    sleep(waitTime);
+  }
+}
+
+export default function () {
+  console.log(`🚀 Starting Faucet API Tests`);
+  console.log(`   API Endpoint: ${API_ENDPOINT}`);
+  console.log(`   RPC Endpoint: ${CALIBNET_RPC}`);
+
+  group('🔧 Health Check', () => {
+    const res = http.get(`${BASE_URL}/`);
+    check(res, {
+      'API is healthy (status 200)': (r) => r.status === 200
+    });
+    if (res.status === 200) {
+      console.log('✅ Health check passed');
+    } else {
+      console.log(`⚠️ Health check returned status: ${res.status}`);
+    }
+  });
+
+  runTestSuite(API_TESTS, 'Main Test Suite (Success & Error Cases)');
+
+  console.log(`\n⏰ Starting Rate Limiting Tests (this may take several minutes)...`);
+  runTestSuite(RATE_LIMIT_TESTS, 'Rate Limiting Test Suite');
+
+  console.log(`\n🏁 Test execution completed!`);
+}

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -8,7 +8,7 @@ use crate::utils::{
 use anyhow::Result;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use leptos::{prelude::ServerFnError, server};
+use leptos::{prelude::ServerFnError, server, server_fn::codec::Json};
 
 #[cfg(feature = "ssr")]
 use alloy::{sol, sol_types::SolCall};
@@ -190,7 +190,7 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
-#[server(endpoint = "claim_token")]
+#[server(endpoint = "claim_token", input = Json)]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: String,

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -191,7 +191,7 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
-#[server(endpoint = "claim_token", input = Json, output = Json)]
+#[server(endpoint = "claim_token", input = Json)]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: String,

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -208,7 +208,7 @@ pub async fn claim_token(
         match faucet_info {
             FaucetInfo::MainnetFIL => {
                 return Err(ServerFnError::ServerError(
-                    "Mainnet token claim is not supported, please use the mainnet faucet"
+                    "Mainnet token claim is not supported."
                         .to_string(),
                 ));
             }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -8,6 +8,7 @@ use crate::utils::{
 use anyhow::Result;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
+use leptos::server_fn::codec::Json;
 use leptos::{prelude::ServerFnError, server};
 
 #[cfg(feature = "ssr")]
@@ -190,7 +191,7 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
-#[server(endpoint = "claim_token")]
+#[server(endpoint = "claim_token", input = Json, output = Json)]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: LotusJson<Address>,
@@ -199,6 +200,7 @@ pub async fn claim_token(
     use crate::utils::message::message_transfer;
     use crate::utils::rpc_context::Provider;
     use fvm_shared::address::Network;
+    use fvm_shared::address::set_current_network;
     use send_wrapper::SendWrapper;
 
     SendWrapper::new(async move {
@@ -212,6 +214,7 @@ pub async fn claim_token(
             }
             FaucetInfo::CalibnetFIL => {
                 let network = Network::Testnet;
+                set_current_network(network);
                 let recipient =
                     parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
@@ -244,6 +247,7 @@ pub async fn claim_token(
             }
             FaucetInfo::CalibnetUSDFC => {
                 let network = Network::Testnet;
+                set_current_network(network);
                 let recipient =
                     parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -8,7 +8,6 @@ use crate::utils::{
 use anyhow::Result;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use leptos::server_fn::codec::Json;
 use leptos::{prelude::ServerFnError, server};
 
 #[cfg(feature = "ssr")]

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -195,14 +195,14 @@ pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: LotusJson<Address>,
 ) -> Result<String, ServerFnError> {
-    use crate::utils::address::AddressAlloyExt;
+    use crate::utils::address::{AddressAlloyExt, parse_address};
     use crate::utils::message::message_transfer;
     use crate::utils::rpc_context::Provider;
     use fvm_shared::address::Network;
     use send_wrapper::SendWrapper;
 
     SendWrapper::new(async move {
-        let LotusJson(recipient) = address;
+        let LotusJson(address) = address;
         match faucet_info {
             FaucetInfo::MainnetFIL => {
                 return Err(ServerFnError::ServerError(
@@ -212,6 +212,8 @@ pub async fn claim_token(
             }
             FaucetInfo::CalibnetFIL => {
                 let network = Network::Testnet;
+                let recipient =
+                    parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
                 let id_address = rpc.lookup_id(recipient).await.map_err(ServerFnError::new)?;
                 let from = faucet_address(faucet_info)
@@ -242,6 +244,8 @@ pub async fn claim_token(
             }
             FaucetInfo::CalibnetUSDFC => {
                 let network = Network::Testnet;
+                let recipient =
+                    parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
                 let owner_fil_address = faucet_address(faucet_info)
                     .await

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -191,7 +191,7 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
-#[server(endpoint = "claim_token", input = Json)]
+#[server(endpoint = "claim_token")]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: String,
@@ -205,11 +205,9 @@ pub async fn claim_token(
 
     SendWrapper::new(async move {
         match faucet_info {
-            FaucetInfo::MainnetFIL => {
-                return Err(ServerFnError::ServerError(
-                    "Mainnet token claim is not supported.".to_string(),
-                ));
-            }
+            FaucetInfo::MainnetFIL => Err(ServerFnError::ServerError(
+                "Mainnet token claim is not supported.".to_string(),
+            )),
             FaucetInfo::CalibnetFIL => {
                 let network = Network::Testnet;
                 set_current_network(network);

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -194,7 +194,7 @@ pub async fn signed_erc20_transfer(
 #[server(endpoint = "claim_token", input = Json, output = Json)]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
-    address: LotusJson<Address>,
+    address: String,
 ) -> Result<String, ServerFnError> {
     use crate::utils::address::{AddressAlloyExt, parse_address};
     use crate::utils::message::message_transfer;
@@ -204,19 +204,16 @@ pub async fn claim_token(
     use send_wrapper::SendWrapper;
 
     SendWrapper::new(async move {
-        let LotusJson(address) = address;
         match faucet_info {
             FaucetInfo::MainnetFIL => {
                 return Err(ServerFnError::ServerError(
-                    "Mainnet token claim is not supported."
-                        .to_string(),
+                    "Mainnet token claim is not supported.".to_string(),
                 ));
             }
             FaucetInfo::CalibnetFIL => {
                 let network = Network::Testnet;
                 set_current_network(network);
-                let recipient =
-                    parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
+                let recipient = parse_address(&address, network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
                 let id_address = rpc.lookup_id(recipient).await.map_err(ServerFnError::new)?;
                 let from = faucet_address(faucet_info)
@@ -248,8 +245,7 @@ pub async fn claim_token(
             FaucetInfo::CalibnetUSDFC => {
                 let network = Network::Testnet;
                 set_current_network(network);
-                let recipient =
-                    parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
+                let recipient = parse_address(&address, network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
                 let owner_fil_address = faucet_address(faucet_info)
                     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod ssr_imports {
         server_fn::axum::register_explicit::<faucet::server_api::SignedFilTransfer>();
         server_fn::axum::register_explicit::<faucet::server_api::SignedErc20Transfer>();
         server_fn::axum::register_explicit::<faucet::server_api::FaucetAddress>();
+        server_fn::axum::register_explicit::<faucet::server_api::ClaimToken>();
     }
 
     #[event(fetch)]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Added `claim_token` server api

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #312 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a faucet claim flow for requesting test tokens (Calibnet FIL and Calibnet USDFC); mainnet claims return a clear not-supported response and successful requests return a transaction ID.

* **Bug Fixes / Reliability**
  * Improved server-side address parsing, nonce/gas handling, signing, and transaction submission for more reliable claim processing.

* **Tests**
  * Added comprehensive E2E k6 tests (API, rate-limiting, on-chain verification) and a CI step to run them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->