### PR TITLE
Calibnet token claim api

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -40,7 +40,7 @@ transaction ID confirming the token transfer.
 
 ---
 
-## Responses
+## Examples
 
 ### Success
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -1,0 +1,74 @@
+# Claim Token API
+
+**Base URL:** `https://forest-explorer.chainsafe.dev`  
+**Endpoint:** `/api/claim_token`  
+**HTTP Method:** `GET`
+
+## Description
+
+The Claim Token API provides a simple way to request calibnet tokens from the
+faucet. This is primarily intended for developers and testers who need tokens to
+interact with the network. Users provide a valid wallet address and specify the
+token type (`faucet_info`) they wish to receive. On success, the API returns a
+transaction ID confirming the token transfer.
+
+**Key points:**
+
+- Each address may be subject to rate limiting to prevent abuse.
+- This API only distributes Calibnet `tFIL` and `tUSDFC` tokens.
+
+---
+
+## Query Parameters
+
+| Parameter     | Type   | Required | Description                                                               |
+| ------------- | ------ | -------- | ------------------------------------------------------------------------- |
+| `faucet_info` | string | Yes      | The type of token to claim. Valid values: `CalibnetFIL`, `CalibnetUSDFC`. |
+| `address`     | string | Yes      | The wallet address to receive the token.                                  |
+
+---
+
+## Status Codes
+
+| Status Code | Description                                                            |
+| ----------- | ---------------------------------------------------------------------- |
+| 200         | Token successfully claimed; response contains transaction ID           |
+| 500         | Server error, including rate limiting; response contains error message |
+
+---
+
+## Responses
+
+### Success
+
+- **Status:** `200 OK`
+- **Content:** Plain JSON string containing the transaction ID.
+
+**Example:**
+
+```bash
+curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=CalibnetFIL&address=t1pxxbe7he3c6vcw5as3gfvq33kprpmlufgtjgfdq"
+```
+
+**Response:**
+
+```bash
+bafy2bzaceam3ihtqa73ru2bdvwoyaouwjwktsonkvs3rwwrn3z43e3xh3y4fk
+```
+
+### Error
+
+- **Status:** `500 Internal Server Error`
+- **Content:** Plain string describing the error.
+
+**Example:**
+
+```bash
+curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=CalibnetFIL&address=invalidaddress"
+```
+
+**Response:**
+
+```bash
+ServerError|Not a valid Testnet address
+```

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -14,7 +14,7 @@ transaction ID confirming the token transfer.
 
 **Key points:**
 
-- Each address may be subject to rate limiting to prevent abuse.
+- Each address is subject to rate limiting to prevent abuse.
 - This API only distributes Calibnet `tFIL` and `tUSDFC` tokens.
 
 ---
@@ -25,6 +25,18 @@ transaction ID confirming the token transfer.
 | ------------- | ------ | -------- | ------------------------------------------------------------------------- |
 | `faucet_info` | string | Yes      | The type of token to claim. Valid values: `CalibnetFIL`, `CalibnetUSDFC`. |
 | `address`     | string | Yes      | The wallet address to receive the token.                                  |
+
+---
+
+## Rate Limits
+
+| Faucet Type     | Cooldown Period | Drip Amount | Wallet Cap | Global Cap   |
+| --------------- | --------------- | ----------- | ---------- | ------------ |
+| `CalibnetFIL`   | 60 seconds      | 1 tFIL      | 2 tFIL     | 200 tFIL     |
+| `CalibnetUSDFC` | 60 seconds      | 5 tUSDFC    | 10 tUSDFC  | 1,000 tUSDFC |
+
+**Note:** All limits reset every 24 hours. Abuse, farming, or automated requests
+are prohibited and may result in stricter limits or bans.
 
 ---
 
@@ -45,7 +57,7 @@ transaction ID confirming the token transfer.
 ### Success
 
 - **Status:** `200 OK`
-- **Content:** Plain JSON string containing the transaction ID.
+- **Content:** Plain text string containing the transaction ID.
 
 **Example:**
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -36,7 +36,7 @@ transaction ID confirming the token transfer.
 | 400         | Bad request - invalid address                                |
 | 429         | Too many requests - rate limited                             |
 | 500         | Server error; response contains error message                |
-| 501         | Not implemented - mainnet not supported                      |
+| 418         | I'm a teapot - mainnet not supported                         |
 
 ---
 
@@ -112,9 +112,9 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet
 Args|unknown variant `Calibnet`, expected one of `MainnetFIL`, `CalibnetFIL`, `CalibnetUSDFC`
 ```
 
-#### 501 Not Implemented
+#### 418 I'm a Teapot
 
-- **Status:** `501 Not Implemented`
+- **Status:** `418 I'm a Teapot`
 - **Content:** Plain string describing the error.
 
 **Example:**
@@ -126,5 +126,5 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=MainnetF
 **Response:**
 
 ```bash
-ServerError|Mainnet token claim is not implemented.
+ServerError|I'm a teapot - mainnet tokens are not available.
 ```

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -30,10 +30,13 @@ transaction ID confirming the token transfer.
 
 ## Status Codes
 
-| Status Code | Description                                                            |
-| ----------- | ---------------------------------------------------------------------- |
-| 200         | Token successfully claimed; response contains transaction ID           |
-| 500         | Server error, including rate limiting; response contains error message |
+| Status Code | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| 200         | Token successfully claimed; response contains transaction ID |
+| 400         | Bad request - invalid address                                |
+| 429         | Too many requests - rate limited                             |
+| 500         | Server error; response contains error message                |
+| 501         | Not implemented - mainnet not supported                      |
 
 ---
 
@@ -56,9 +59,11 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet
 bafy2bzaceam3ihtqa73ru2bdvwoyaouwjwktsonkvs3rwwrn3z43e3xh3y4fk
 ```
 
-### Error
+### Failure
 
-- **Status:** `500 Internal Server Error`
+#### 400 Bad Request
+
+- **Status:** `400 Bad Request`
 - **Content:** Plain string describing the error.
 
 **Example:**
@@ -70,5 +75,56 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet
 **Response:**
 
 ```bash
-ServerError|Not a valid Testnet address
+ServerError|Invalid address: Not a valid Testnet address
+```
+
+#### 429 Too Many Requests
+
+- **Status:** `429 Too Many Requests`
+- **Content:** Plain string describing the rate limit error.
+
+**Example:**
+
+```bash
+curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=CalibnetFIL&address=t1pxxbe7he3c6vcw5as3gfvq33kprpmlufgtjgfdq"
+```
+
+**Response:**
+
+```bash
+ServerError|Too many requests: Rate limited. Try again in 60 seconds.
+```
+
+#### 500 Internal Server Error
+
+- **Status:** `500 Internal Server Error`
+- **Content:** Plain string describing the server error.
+
+**Example:**
+
+```bash
+curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet&address=t1pxxbe7he3c6vcw5as3gfvq33kprpmlufgtjgfdq"
+```
+
+**Response:**
+
+```bash
+Args|unknown variant `Calibnet`, expected one of `MainnetFIL`, `CalibnetFIL`, `CalibnetUSDFC`
+```
+
+#### 501 Not Implemented
+
+- **Status:** `501 Not Implemented`
+- **Content:** Plain string describing the error.
+
+**Example:**
+
+```bash
+curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=MainnetFIL&address=f1rgci272nfk4k6cpyejepzv4xstpejjckldlzidy"
+```
+
+**Response:**
+
+```bash
+ServerError|Mainnet token claim is not implemented.
 ```

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -245,7 +245,7 @@ async fn handle_native_claim(
 ) -> Result<String, ServerFnError> {
     use crate::utils::message::message_transfer;
     use crate::utils::rpc_context::Provider;
-    use fvm_shared::address::{Network, set_current_network};
+    use fvm_shared::address::set_current_network;
 
     let network = faucet_info.network();
     set_current_network(network);
@@ -295,7 +295,7 @@ async fn handle_erc20_claim(
 ) -> Result<String, ServerFnError> {
     use crate::utils::address::AddressAlloyExt;
     use crate::utils::rpc_context::Provider;
-    use fvm_shared::address::{Network, set_current_network};
+    use fvm_shared::address::set_current_network;
 
     let network = faucet_info.network();
     set_current_network(network);

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -247,7 +247,7 @@ async fn handle_native_claim(
     use crate::utils::rpc_context::Provider;
     use fvm_shared::address::{Network, set_current_network};
 
-    let network = Network::Testnet;
+    let network = faucet_info.network();
     set_current_network(network);
 
     let recipient = parse_and_validate_address(&address, network, response)?;
@@ -297,7 +297,7 @@ async fn handle_erc20_claim(
     use crate::utils::rpc_context::Provider;
     use fvm_shared::address::{Network, set_current_network};
 
-    let network = Network::Testnet;
+    let network = faucet_info.network();
     set_current_network(network);
 
     let recipient = parse_and_validate_address(&address, network, response)?;

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -307,15 +307,12 @@ async fn handle_erc20_claim(
         .await?
         .to_filecoin_address(network)
         .map_err(ServerFnError::new)?;
-    let eth_to = recipient
-        .into_eth_address()
-        .map_err(|e| ServerFnError::new(e))?;
+    let eth_to = recipient.into_eth_address().map_err(ServerFnError::new)?;
     let nonce = rpc
         .mpool_get_nonce(owner_fil_address)
         .await
         .map_err(ServerFnError::new)?;
     let gas_price = rpc.gas_price().await.map_err(ServerFnError::new)?;
-    let drip_amount = faucet_info.drip_amount();
 
     match signed_erc20_transfer(eth_to, nonce, gas_price, faucet_info).await {
         Ok(signed) => {

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -8,7 +8,7 @@ use crate::utils::{
 use anyhow::Result;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use leptos::{prelude::ServerFnError, server};
+use leptos::{prelude::ServerFnError, server, server_fn::codec::Json};
 
 #[cfg(feature = "ssr")]
 use alloy::{sol, sol_types::SolCall};
@@ -190,7 +190,7 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
-#[server(endpoint = "claim_token")]
+#[server(endpoint = "claim_token", input = Json)]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: String,

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -191,7 +191,7 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
-#[server(endpoint = "claim_token", input = Json, output = Json)]
+#[server(endpoint = "claim_token", input = Json)]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: String,

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -266,7 +266,7 @@ pub async fn claim_token(
                                 e
                             )));
                         }
-                        return Err(ServerFnError::ServerError(format!("{}", e)));
+                        Err(ServerFnError::ServerError(format!("{}", e)))
                     }
                 }
             }
@@ -313,7 +313,7 @@ pub async fn claim_token(
                                 e
                             )));
                         }
-                        return Err(ServerFnError::ServerError(format!("{}", e)));
+                        Err(ServerFnError::ServerError(format!("{}", e)))
                     }
                 }
             }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -208,7 +208,7 @@ pub async fn claim_token(
         match faucet_info {
             FaucetInfo::MainnetFIL => {
                 return Err(ServerFnError::ServerError(
-                    "Mainnet token claim is not supported, please use the mainnet faucet"
+                    "Mainnet token claim is not supported."
                         .to_string(),
                 ));
             }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -8,6 +8,7 @@ use crate::utils::{
 use anyhow::Result;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
+use leptos::server_fn::codec::Json;
 use leptos::{prelude::ServerFnError, server};
 
 #[cfg(feature = "ssr")]
@@ -190,7 +191,7 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
-#[server(endpoint = "claim_token")]
+#[server(endpoint = "claim_token", input = Json, output = Json)]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: LotusJson<Address>,
@@ -199,6 +200,7 @@ pub async fn claim_token(
     use crate::utils::message::message_transfer;
     use crate::utils::rpc_context::Provider;
     use fvm_shared::address::Network;
+    use fvm_shared::address::set_current_network;
     use send_wrapper::SendWrapper;
 
     SendWrapper::new(async move {
@@ -212,6 +214,7 @@ pub async fn claim_token(
             }
             FaucetInfo::CalibnetFIL => {
                 let network = Network::Testnet;
+                set_current_network(network);
                 let recipient =
                     parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
@@ -244,6 +247,7 @@ pub async fn claim_token(
             }
             FaucetInfo::CalibnetUSDFC => {
                 let network = Network::Testnet;
+                set_current_network(network);
                 let recipient =
                     parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -8,7 +8,6 @@ use crate::utils::{
 use anyhow::Result;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use leptos::server_fn::codec::Json;
 use leptos::{prelude::ServerFnError, server};
 
 #[cfg(feature = "ssr")]

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -255,19 +255,20 @@ pub async fn claim_token(
                         let cid = rpc.mpool_push(smsg).await.map_err(ServerFnError::new)?;
                         Ok(cid.to_string())
                     }
-                    Err(e) => {
-                        if let FaucetError::RateLimited {
+                    Err(err) => match err {
+                        FaucetError::RateLimited {
                             retry_after_secs: _,
-                        } = e
-                        {
+                        } => {
                             response.set_status(http::StatusCode::TOO_MANY_REQUESTS);
-                            return Err(ServerFnError::ServerError(format!(
+                            Err(ServerFnError::ServerError(format!(
                                 "Too many requests: {}",
-                                e
-                            )));
+                                err
+                            )))
                         }
-                        Err(ServerFnError::ServerError(format!("{}", e)))
-                    }
+                        FaucetError::Server(_) => {
+                            Err(ServerFnError::ServerError(format!("{}", err)))
+                        }
+                    },
                 }
             }
             FaucetInfo::CalibnetUSDFC => {
@@ -302,19 +303,20 @@ pub async fn claim_token(
                             .map_err(ServerFnError::new)?;
                         Ok(tx_id.to_string())
                     }
-                    Err(e) => {
-                        if let FaucetError::RateLimited {
+                    Err(err) => match err {
+                        FaucetError::RateLimited {
                             retry_after_secs: _,
-                        } = e
-                        {
+                        } => {
                             response.set_status(http::StatusCode::TOO_MANY_REQUESTS);
-                            return Err(ServerFnError::ServerError(format!(
+                            Err(ServerFnError::ServerError(format!(
                                 "Too many requests: {}",
-                                e
-                            )));
+                                err
+                            )))
                         }
-                        Err(ServerFnError::ServerError(format!("{}", e)))
-                    }
+                        FaucetError::Server(_) => {
+                            Err(ServerFnError::ServerError(format!("{}", err)))
+                        }
+                    },
                 }
             }
         }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -195,14 +195,14 @@ pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: LotusJson<Address>,
 ) -> Result<String, ServerFnError> {
-    use crate::utils::address::AddressAlloyExt;
+    use crate::utils::address::{AddressAlloyExt, parse_address};
     use crate::utils::message::message_transfer;
     use crate::utils::rpc_context::Provider;
     use fvm_shared::address::Network;
     use send_wrapper::SendWrapper;
 
     SendWrapper::new(async move {
-        let LotusJson(recipient) = address;
+        let LotusJson(address) = address;
         match faucet_info {
             FaucetInfo::MainnetFIL => {
                 return Err(ServerFnError::ServerError(
@@ -212,6 +212,8 @@ pub async fn claim_token(
             }
             FaucetInfo::CalibnetFIL => {
                 let network = Network::Testnet;
+                let recipient =
+                    parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
                 let id_address = rpc.lookup_id(recipient).await.map_err(ServerFnError::new)?;
                 let from = faucet_address(faucet_info)
@@ -242,6 +244,8 @@ pub async fn claim_token(
             }
             FaucetInfo::CalibnetUSDFC => {
                 let network = Network::Testnet;
+                let recipient =
+                    parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
                 let owner_fil_address = faucet_address(faucet_info)
                     .await

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -191,7 +191,7 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
-#[server(endpoint = "claim_token", input = Json)]
+#[server(endpoint = "claim_token")]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: String,
@@ -205,11 +205,9 @@ pub async fn claim_token(
 
     SendWrapper::new(async move {
         match faucet_info {
-            FaucetInfo::MainnetFIL => {
-                return Err(ServerFnError::ServerError(
-                    "Mainnet token claim is not supported.".to_string(),
-                ));
-            }
+            FaucetInfo::MainnetFIL => Err(ServerFnError::ServerError(
+                "Mainnet token claim is not supported.".to_string(),
+            )),
             FaucetInfo::CalibnetFIL => {
                 let network = Network::Testnet;
                 set_current_network(network);

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -253,7 +253,10 @@ async fn handle_native_claim(
     let recipient = parse_and_validate_address(&address, network, response)?;
     let rpc = Provider::from_network(network);
 
-    let id_address = rpc.lookup_id(recipient).await.map_err(ServerFnError::new)?;
+    let id_address = rpc.lookup_id(recipient).await.unwrap_or_else(|_| {
+        log::debug!("ID lookup failed, using recipient address: {:?}", recipient);
+        recipient
+    });
     let from = faucet_address(faucet_info)
         .await?
         .to_filecoin_address(network)

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -208,9 +208,9 @@ pub async fn claim_token(
     SendWrapper::new(async move {
         match faucet_info {
             FaucetInfo::MainnetFIL => {
-                response.set_status(http::StatusCode::NOT_IMPLEMENTED);
+                response.set_status(http::StatusCode::IM_A_TEAPOT);
                 Err(ServerFnError::ServerError(
-                    "Mainnet token claim is not implemented.".to_string(),
+                    "I'm a teapot - mainnet tokens are not available.".to_string(),
                 ))
             }
             FaucetInfo::CalibnetFIL => {

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -8,7 +8,7 @@ use crate::utils::{
 use anyhow::Result;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use leptos::{prelude::ServerFnError, server, server_fn::codec::Json};
+use leptos::{prelude::ServerFnError, server, server_fn::codec::GetUrl};
 
 #[cfg(feature = "ssr")]
 use alloy::{sol, sol_types::SolCall};
@@ -190,7 +190,7 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
-#[server(endpoint = "claim_token", input = Json)]
+#[server(endpoint = "claim_token", input = GetUrl)]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: String,

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -194,7 +194,7 @@ pub async fn signed_erc20_transfer(
 #[server(endpoint = "claim_token", input = Json, output = Json)]
 pub async fn claim_token(
     faucet_info: FaucetInfo,
-    address: LotusJson<Address>,
+    address: String,
 ) -> Result<String, ServerFnError> {
     use crate::utils::address::{AddressAlloyExt, parse_address};
     use crate::utils::message::message_transfer;
@@ -204,19 +204,16 @@ pub async fn claim_token(
     use send_wrapper::SendWrapper;
 
     SendWrapper::new(async move {
-        let LotusJson(address) = address;
         match faucet_info {
             FaucetInfo::MainnetFIL => {
                 return Err(ServerFnError::ServerError(
-                    "Mainnet token claim is not supported."
-                        .to_string(),
+                    "Mainnet token claim is not supported.".to_string(),
                 ));
             }
             FaucetInfo::CalibnetFIL => {
                 let network = Network::Testnet;
                 set_current_network(network);
-                let recipient =
-                    parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
+                let recipient = parse_address(&address, network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
                 let id_address = rpc.lookup_id(recipient).await.map_err(ServerFnError::new)?;
                 let from = faucet_address(faucet_info)
@@ -248,8 +245,7 @@ pub async fn claim_token(
             FaucetInfo::CalibnetUSDFC => {
                 let network = Network::Testnet;
                 set_current_network(network);
-                let recipient =
-                    parse_address(&address.to_string(), network).map_err(ServerFnError::new)?;
+                let recipient = parse_address(&address, network).map_err(ServerFnError::new)?;
                 let rpc = Provider::from_network(network);
                 let owner_fil_address = faucet_address(faucet_info)
                     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod ssr_imports {
         server_fn::axum::register_explicit::<faucet::server_api::SignedFilTransfer>();
         server_fn::axum::register_explicit::<faucet::server_api::SignedErc20Transfer>();
         server_fn::axum::register_explicit::<faucet::server_api::FaucetAddress>();
+        server_fn::axum::register_explicit::<faucet::server_api::ClaimToken>();
     }
 
     #[event(fetch)]


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Introduced a new server api `/api/claim_token` to request calibnet tokens from faucet.
- Added API Documentation (docs/api-documentation.md)

Preview URL: https://6a73e1c.forest-explorer-preview.workers.dev

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Implements #312 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Claim Token API to request Calibnet FIL and Calibnet USDFC to a specified wallet address; returns a transaction ID on success. Requests for Mainnet FIL are not supported (will return a teapot error/status).

* **Documentation**
  * Added API docs for /api/claim_token: base URL, query parameters (faucet_info, address), status codes (200, 400, 429, 500, 418) and example curl requests/responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->