### PR TITLE
Update claim token API to return transaction hash

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -10,7 +10,7 @@ The Claim Token API provides a simple way to request calibnet tokens from the
 faucet. This is primarily intended for developers and testers who need tokens to
 interact with the network. Users provide a valid wallet address and specify the
 token type (`faucet_info`) they wish to receive. On success, the API returns a
-transaction ID confirming the token transfer.
+transaction hash confirming the token transfer.
 
 **Key points:**
 
@@ -42,13 +42,13 @@ are prohibited and may result in stricter limits or bans.
 
 ## Status Codes
 
-| Status Code | Description                                                  |
-| ----------- | ------------------------------------------------------------ |
-| 200         | Token successfully claimed; response contains transaction ID |
-| 400         | Bad request - invalid address                                |
-| 429         | Too many requests - rate limited                             |
-| 500         | Server error; response contains error message                |
-| 418         | I'm a teapot - mainnet not supported                         |
+| Status Code | Description                                                    |
+| ----------- | -------------------------------------------------------------- |
+| 200         | Token successfully claimed; response contains transaction hash |
+| 400         | Bad request - invalid address                                  |
+| 429         | Too many requests - rate limited                               |
+| 500         | Server error; response contains error message                  |
+| 418         | I'm a teapot - mainnet not supported                           |
 
 ---
 
@@ -57,7 +57,7 @@ are prohibited and may result in stricter limits or bans.
 ### Success
 
 - **Status:** `200 OK`
-- **Content:** Plain text string containing the transaction ID.
+- **Content:** Plain text string containing the transaction hash.
 
 **Example:**
 
@@ -68,7 +68,7 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet
 **Response:**
 
 ```bash
-bafy2bzaceam3ihtqa73ru2bdvwoyaouwjwktsonkvs3rwwrn3z43e3xh3y4fk
+0x06784dd239f7f0e01baa19a82877e17b7fcd6e1dd725913fd6f741a2a6c56ce5
 ```
 
 ### Failure

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -289,7 +289,11 @@ async fn handle_native_claim(
     {
         Ok(LotusJson(smsg)) => {
             let cid = rpc.mpool_push(smsg).await.map_err(ServerFnError::new)?;
-            Ok(cid.to_string())
+            let tx_hash = rpc
+                .eth_get_transaction_hash_by_cid(cid)
+                .await
+                .map_err(ServerFnError::new)?;
+            Ok(tx_hash.to_string())
         }
         Err(err) => Err(handle_faucet_error(err)),
     }
@@ -313,11 +317,11 @@ async fn handle_erc20_claim(
 
     match signed_erc20_transfer(eth_to, nonce, gas_price, faucet_info).await {
         Ok(signed) => {
-            let tx_id = rpc
+            let tx_hash = rpc
                 .send_eth_transaction_signed(&signed)
                 .await
                 .map_err(ServerFnError::new)?;
-            Ok(tx_id.to_string())
+            Ok(tx_hash.to_string())
         }
         Err(err) => Err(handle_faucet_error(err)),
     }

--- a/src/utils/lotus_json/mod.rs
+++ b/src/utils/lotus_json/mod.rs
@@ -119,6 +119,7 @@
 //! - use a derive macro for simple compound structs
 
 use ::cid::Cid;
+use alloy::primitives::TxHash;
 use derive_more::From;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::DeserializeOwned};
 use std::{fmt::Display, str::FromStr};
@@ -383,6 +384,7 @@ lotus_json_with_self!(
     (),
     std::path::PathBuf,
     bool,
+    TxHash,
 );
 
 // TODO(forest): https://github.com/ChainSafe/forest/issues/4032

--- a/src/utils/rpc_context.rs
+++ b/src/utils/rpc_context.rs
@@ -257,6 +257,15 @@ impl Provider {
         .await
     }
 
+    pub async fn eth_get_transaction_hash_by_cid(&self, cid: Cid) -> anyhow::Result<TxHash> {
+        invoke_rpc_method(
+            &self.url,
+            "Filecoin.EthGetTransactionHashByCid",
+            &[serde_json::to_value(LotusJson(cid))?],
+        )
+        .await
+    }
+
     pub async fn state_search_msg(
         &self,
         msg: Cid,


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Return transaction hash instead of cid for calibnet `tFIL` transaction in `claim_token` server API.
- Use `Filecoin.EthGetTransactionHashByCid` to get transaction hash from cid.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md
