### PR TITLE
Add fallback for tx hash resolution by cid in claim token API

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -16,6 +16,9 @@ transaction hash confirming the token transfer.
 
 - Each address is subject to rate limiting to prevent abuse.
 - This API only distributes Calibnet `tFIL` and `tUSDFC` tokens.
+- For native token claims, the API returns the Ethereum transaction hash if
+  resolvable via `Filecoin.EthGetTransactionHashByCid`; otherwise, it returns
+  the CID.
 
 ---
 

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -293,7 +293,14 @@ async fn handle_native_claim(
                 .eth_get_transaction_hash_by_cid(cid)
                 .await
                 .map(|tx_hash| tx_hash.to_string())
-                .unwrap_or_else(|_| cid.to_string()))
+                .unwrap_or_else(|err| {
+                    log::warn!(
+                        "Failed to resolve tx hash for CID {}: {}. Returning CID instead.",
+                        cid,
+                        err
+                    );
+                    cid.to_string()
+                }))
         }
         Err(err) => Err(handle_faucet_error(err)),
     }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -289,11 +289,11 @@ async fn handle_native_claim(
     {
         Ok(LotusJson(smsg)) => {
             let cid = rpc.mpool_push(smsg).await.map_err(ServerFnError::new)?;
-            let tx_hash = rpc
+            Ok(rpc
                 .eth_get_transaction_hash_by_cid(cid)
                 .await
-                .map_err(ServerFnError::new)?;
-            Ok(tx_hash.to_string())
+                .map(|tx_hash| tx_hash.to_string())
+                .unwrap_or_else(|_| cid.to_string()))
         }
         Err(err) => Err(handle_faucet_error(err)),
     }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -295,9 +295,7 @@ async fn handle_native_claim(
                 .map(|tx_hash| tx_hash.to_string())
                 .unwrap_or_else(|err| {
                     log::warn!(
-                        "Failed to resolve tx hash for CID {}: {}. Returning CID instead.",
-                        cid,
-                        err
+                        "Failed to resolve tx hash for CID {cid}: {err}. Returning CID instead."
                     );
                     cid.to_string()
                 }))


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

This PR fixes the issue reported in https://filecoinproject.slack.com/archives/C08UEF3HNLQ/p1760080099927249

- If we fail to resolve transaction hash from CID using `Filecoin.EthGetTransactionHashByCid` , we now return CID instead of `Null`.

Preview URL: https://7c29166.forest-explorer-preview.workers.dev

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Native token claim handling is more resilient: if an Ethereum transaction hash cannot be resolved, the response now falls back to returning the CID instead of failing.

* **Documentation**
  * API docs clarified: native token claim responses include the Ethereum transaction hash when resolvable; otherwise the CID is returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->