### PR TITLE
Implement claim all calibnet token API

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -236,20 +236,20 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?address=invalida
 
 **Response:**
 
-```bash
+```json
 [
-    {
-        "faucet_info": "CalibnetUSDFC",
-        "error": {
-            "ServerError": "Invalid address: Not a valid Testnet address"
-        }
-    },
-    {
-        "faucet_info": "CalibnetFIL",
-        "error": {
-            "ServerError": "Invalid address: Not a valid Testnet address"
-        }
+  {
+    "faucet_info": "CalibnetUSDFC",
+    "error": {
+      "ServerError": "Invalid address: Not a valid Testnet address"
     }
+  },
+  {
+    "faucet_info": "CalibnetFIL",
+    "error": {
+      "ServerError": "Invalid address: Not a valid Testnet address"
+    }
+  }
 ]
 ```
 
@@ -268,20 +268,20 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?address=0xAe9C4b
 
 **Response:**
 
-```bash
+```json
 [
-    {
-        "faucet_info": "CalibnetUSDFC",
-        "error": {
-            "ServerError": "Too many requests: Rate limited. Try again in 46 seconds."
-        }
-    },
-    {
-        "faucet_info": "CalibnetFIL",
-        "error": {
-            "ServerError": "Too many requests: Rate limited. Try again in 12 seconds."
-        }
+  {
+    "faucet_info": "CalibnetUSDFC",
+    "error": {
+      "ServerError": "Too many requests: Rate limited. Try again in 46 seconds."
     }
+  },
+  {
+    "faucet_info": "CalibnetFIL",
+    "error": {
+      "ServerError": "Too many requests: Rate limited. Try again in 12 seconds."
+    }
+  }
 ]
 ```
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -231,7 +231,7 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?address=0xAe9C4b
 **Example:**
 
 ```bash
-curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=CalibnetFIL&address=invalidaddress"
+curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?faucet_info=CalibnetFIL&address=invalidaddress"
 ```
 
 **Response:**
@@ -263,7 +263,7 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet
 **Example:**
 
 ```bash
-curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=CalibnetFIL&address=0xAe9C4b9508c929966ef37209b336E5796D632CDc"
+curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?faucet_info=CalibnetFIL&address=0xAe9C4b9508c929966ef37209b336E5796D632CDc"
 ```
 
 **Response:**

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -231,7 +231,7 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?address=0xAe9C4b
 **Example:**
 
 ```bash
-curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?faucet_info=CalibnetFIL&address=invalidaddress"
+curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?address=invalidaddress"
 ```
 
 **Response:**
@@ -263,7 +263,7 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?faucet_info=Cali
 **Example:**
 
 ```bash
-curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?faucet_info=CalibnetFIL&address=0xAe9C4b9508c929966ef37209b336E5796D632CDc"
+curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?address=0xAe9C4b9508c929966ef37209b336E5796D632CDc"
 ```
 
 **Response:**

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -10,12 +10,7 @@ The Claim Token API provides a simple way to request calibnet tokens from the
 faucet. This is primarily intended for developers and testers who need tokens to
 interact with the network. Users provide a valid wallet address and specify the
 token type (`faucet_info`) they wish to receive. On success, the API returns a
-transaction hash confirming the token transfer.
-
-**Key points:**
-
-- Each address is subject to rate limiting to prevent abuse.
-- This API only distributes Calibnet `tFIL` and `tUSDFC` tokens.
+JSON object with `faucet_info` and `tx_hash` confirming the token transfer.
 
 ---
 
@@ -25,18 +20,6 @@ transaction hash confirming the token transfer.
 | ------------- | ------ | -------- | ------------------------------------------------------------------------- |
 | `faucet_info` | string | Yes      | The type of token to claim. Valid values: `CalibnetFIL`, `CalibnetUSDFC`. |
 | `address`     | string | Yes      | The wallet address to receive the token.                                  |
-
----
-
-## Rate Limits
-
-| Faucet Type     | Cooldown Period | Drip Amount | Wallet Cap | Global Cap   |
-| --------------- | --------------- | ----------- | ---------- | ------------ |
-| `CalibnetFIL`   | 60 seconds      | 1 tFIL      | 2 tFIL     | 200 tFIL     |
-| `CalibnetUSDFC` | 60 seconds      | 5 tUSDFC    | 10 tUSDFC  | 1,000 tUSDFC |
-
-**Note:** All limits reset every 24 hours. Abuse, farming, or automated requests
-are prohibited and may result in stricter limits or bans.
 
 ---
 
@@ -56,8 +39,10 @@ are prohibited and may result in stricter limits or bans.
 
 ### Success
 
+#### Success claim for `CalibnetFIL`
+
 - **Status:** `200 OK`
-- **Content:** Plain text string containing the transaction hash.
+- **Content:** JSON with faucet info and transaction hash.
 
 **Example:**
 
@@ -67,8 +52,29 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet
 
 **Response:**
 
+```json
+{
+  "faucet_info": "CalibnetFIL",
+  "tx_hash": "0x06784dd239f7f0e01baa19a82877e17b7fcd6e1dd725913fd6f741a2a6c56ce5"
+}
+```
+
+#### Success claim for `CalibnetUSDFC`
+
+- **Status:** `200 OK`
+- **Content:** JSON with faucet info and transaction hash.
+
 ```bash
-0x06784dd239f7f0e01baa19a82877e17b7fcd6e1dd725913fd6f741a2a6c56ce5
+curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=CalibnetUSDFC&address=0xae9c4b9508c929966ef37209b336e5796d632cdc"
+```
+
+**Response:**
+
+```json
+{
+  "faucet_info": "CalibnetUSDFC",
+  "tx_hash": "0x8d75e2394dcf829ab9353370069b6d6afb04c88ea38c765ab4443a1587e12922"
+}
 ```
 
 ### Failure
@@ -140,6 +146,167 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=MainnetF
 ```bash
 ServerError|I'm a teapot - mainnet tokens are not available.
 ```
+
+---
+
+# Claim Token All API
+
+**Base URL:** `https://forest-explorer.chainsafe.dev`  
+**Endpoint:** `/api/claim_token_all`  
+**HTTP Method:** `GET`
+
+## Description
+
+Requests claims for both `CalibnetUSDFC` and `CalibnetFIL` in one call. Returns
+a JSON array of per-claim results. Each item corresponds to one faucet claim.
+
+---
+
+## Query Parameters
+
+| Parameter | Type   | Required | Description                                   |
+| --------- | ------ | -------- | --------------------------------------------- |
+| `address` | string | Yes      | The wallet address to receive all the tokens. |
+
+---
+
+## Status Codes
+
+| Status Code | Description                      |
+| ----------- | -------------------------------- |
+| 200         | Tokens successfully claimed      |
+| 400         | Bad request - invalid address    |
+| 429         | Too many requests - rate limited |
+| 500         | Server error                     |
+
+---
+
+### Claim Response Success & Failure
+
+The API returns a **JSON array**, where each object corresponds to a faucet
+claim attempt. Each object contains:
+
+- `faucet_info`: A string identifying the faucet (e.g., `CalibnetFIL`,
+  `CalibnetUSDFC`)
+
+And either:
+
+- `tx_hash`: A string containing the transaction hash **if the claim was
+  successful**,  
+  **or**
+- `error`: An object containing the error details **if the claim failed**
+
+---
+
+## Examples
+
+### Success
+
+- **Status:** `200 OK`
+
+**Example:**
+
+```bash
+curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?address=0xAe9C4b9508c929966ef37209b336E5796D632CDc"
+```
+
+**Response:**
+
+```json
+[
+  {
+    "faucet_info": "CalibnetUSDFC",
+    "tx_hash": "0x8d75e2394dcf829ab9353370069b6d6afb04c88ea38c765ab4443a1587e12922"
+  },
+  {
+    "faucet_info": "CalibnetFIL",
+    "tx_hash": "0xf133c6aae45e40a48b71449229cb45f5ab5f2e7bd8ae488d1142319191ca8eb0"
+  }
+]
+```
+
+### Failure
+
+#### 400 Bad Request
+
+- **Status:** `400 Bad Request`
+- **Content:** JSON array where each item represents a faucet claim result. Each
+  item includes `faucet_info` and either a `tx_hash` (on success) or an `error`
+  object (on failure).
+
+**Example:**
+
+```bash
+curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=CalibnetFIL&address=invalidaddress"
+```
+
+**Response:**
+
+```bash
+[
+    {
+        "faucet_info": "CalibnetUSDFC",
+        "error": {
+            "ServerError": "Invalid address: Not a valid Testnet address"
+        }
+    },
+    {
+        "faucet_info": "CalibnetFIL",
+        "error": {
+            "ServerError": "Invalid address: Not a valid Testnet address"
+        }
+    }
+]
+```
+
+#### 429 Too Many Requests
+
+- **Status:** `429 Too Many Requests`
+- **Content:** JSON array where each item represents a faucet claim result. Each
+  item includes `faucet_info` and either a `tx_hash` (on success) or an `error`
+  object (on failure).
+
+**Example:**
+
+```bash
+curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=CalibnetFIL&address=0xAe9C4b9508c929966ef37209b336E5796D632CDc"
+```
+
+**Response:**
+
+```bash
+[
+    {
+        "faucet_info": "CalibnetUSDFC",
+        "error": {
+            "ServerError": "Too many requests: Rate limited. Try again in 46 seconds."
+        }
+    },
+    {
+        "faucet_info": "CalibnetFIL",
+        "error": {
+            "ServerError": "Too many requests: Rate limited. Try again in 12 seconds."
+        }
+    }
+]
+```
+
+---
+
+**Key points:**
+
+- Each address is subject to rate limiting to prevent abuse.
+- This API only distributes Calibnet `tFIL` and `tUSDFC` tokens.
+
+## Rate Limits
+
+| Faucet Type     | Cooldown Period | Drip Amount | Wallet Cap | Global Cap   |
+| --------------- | --------------- | ----------- | ---------- | ------------ |
+| `CalibnetFIL`   | 60 seconds      | 1 tFIL      | 2 tFIL     | 200 tFIL     |
+| `CalibnetUSDFC` | 60 seconds      | 5 tUSDFC    | 10 tUSDFC  | 1,000 tUSDFC |
+
+**Note:** All limits reset every 24 hours. Abuse, farming, or automated requests
+are prohibited and may result in stricter limits or bans.
 
 ---
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -10,7 +10,7 @@ The Claim Token API provides a simple way to request calibnet tokens from the
 faucet. This is primarily intended for developers and testers who need tokens to
 interact with the network. Users provide a valid wallet address and specify the
 token type (`faucet_info`) they wish to receive. On success, the API returns a
-JSON object with `faucet_info` and `tx_hash` confirming the token transfer.
+transaction hash confirming the token transfer.
 
 ---
 
@@ -42,7 +42,7 @@ JSON object with `faucet_info` and `tx_hash` confirming the token transfer.
 #### Success claim for `CalibnetFIL`
 
 - **Status:** `200 OK`
-- **Content:** JSON with faucet info and transaction hash.
+- **Content:** Plain text string containing the transaction hash.
 
 **Example:**
 
@@ -52,17 +52,14 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet
 
 **Response:**
 
-```json
-{
-  "faucet_info": "CalibnetFIL",
-  "tx_hash": "0x06784dd239f7f0e01baa19a82877e17b7fcd6e1dd725913fd6f741a2a6c56ce5"
-}
+```bash
+0x06784dd239f7f0e01baa19a82877e17b7fcd6e1dd725913fd6f741a2a6c56ce5
 ```
 
 #### Success claim for `CalibnetUSDFC`
 
 - **Status:** `200 OK`
-- **Content:** JSON with faucet info and transaction hash.
+- **Content:** Plain text string containing the transaction hash.
 
 ```bash
 curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=CalibnetUSDFC&address=0xae9c4b9508c929966ef37209b336e5796d632cdc"
@@ -70,11 +67,8 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet
 
 **Response:**
 
-```json
-{
-  "faucet_info": "CalibnetUSDFC",
-  "tx_hash": "0x8d75e2394dcf829ab9353370069b6d6afb04c88ea38c765ab4443a1587e12922"
-}
+```bash
+0x8d75e2394dcf829ab9353370069b6d6afb04c88ea38c765ab4443a1587e12922
 ```
 
 ### Failure

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -350,7 +350,7 @@ async fn handle_native_claim(
                 .await
                 .map_err(ServerFnError::new)?;
             Ok(ClaimResponse {
-                faucet_info: faucet_info,
+                faucet_info,
                 tx_hash: Some(tx_hash),
                 error: None,
             })
@@ -382,7 +382,7 @@ async fn handle_erc20_claim(
                 .await
                 .map_err(ServerFnError::new)?;
             Ok(ClaimResponse {
-                faucet_info: faucet_info,
+                faucet_info,
                 tx_hash: Some(tx_hash),
                 error: None,
             })

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -200,7 +200,7 @@ pub async fn signed_erc20_transfer(
 
 #[derive(Serialize, Deserialize)]
 pub struct ClaimResponse {
-    pub faucet: FaucetInfo,
+    pub faucet_info: FaucetInfo,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tx_hash: Option<TxHash>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -254,7 +254,7 @@ pub async fn claim_token_all(address: String) -> Result<Vec<ClaimResponse>, Serv
     match claim_token(FaucetInfo::CalibnetUSDFC, address.clone()).await {
         Ok(resp) => results.push(resp),
         Err(e) => results.push(ClaimResponse {
-            faucet: FaucetInfo::CalibnetUSDFC,
+            faucet_info: FaucetInfo::CalibnetUSDFC,
             tx_hash: None,
             error: Some(e),
         }),
@@ -263,7 +263,7 @@ pub async fn claim_token_all(address: String) -> Result<Vec<ClaimResponse>, Serv
     match claim_token(FaucetInfo::CalibnetFIL, address).await {
         Ok(resp) => results.push(resp),
         Err(e) => results.push(ClaimResponse {
-            faucet: FaucetInfo::CalibnetFIL,
+            faucet_info: FaucetInfo::CalibnetFIL,
             tx_hash: None,
             error: Some(e),
         }),
@@ -350,7 +350,7 @@ async fn handle_native_claim(
                 .await
                 .map_err(ServerFnError::new)?;
             Ok(ClaimResponse {
-                faucet: faucet_info,
+                faucet_info: faucet_info,
                 tx_hash: Some(tx_hash),
                 error: None,
             })
@@ -382,7 +382,7 @@ async fn handle_erc20_claim(
                 .await
                 .map_err(ServerFnError::new)?;
             Ok(ClaimResponse {
-                faucet: faucet_info,
+                faucet_info: faucet_info,
                 tx_hash: Some(tx_hash),
                 error: None,
             })

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -5,10 +5,12 @@ use crate::utils::{
     address::AnyAddress,
     lotus_json::{LotusJson, signed_message::SignedMessage},
 };
+use alloy::primitives::TxHash;
 use anyhow::Result;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
 use leptos::{prelude::ServerFnError, server, server_fn::codec::GetUrl};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "ssr")]
 use axum::http::StatusCode;
@@ -196,6 +198,15 @@ pub async fn signed_erc20_transfer(
     Ok(signed)
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct ClaimResponse {
+    pub faucet: FaucetInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_hash: Option<TxHash>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ServerFnError>,
+}
+
 /// Server API endpoint for claiming calibnet tokens from the faucet.
 /// Returns a transaction ID on successful token claim.
 /// Supports distribution of `CalibnetFIL` and `CalibnetUSDFC` tokens.
@@ -204,7 +215,7 @@ pub async fn signed_erc20_transfer(
 pub async fn claim_token(
     faucet_info: FaucetInfo,
     address: String,
-) -> Result<String, ServerFnError> {
+) -> Result<ClaimResponse, ServerFnError> {
     use crate::utils::rpc_context::Provider;
     use fvm_shared::address::set_current_network;
     use send_wrapper::SendWrapper;
@@ -234,6 +245,31 @@ pub async fn claim_token(
         }
     })
     .await
+}
+
+#[server(endpoint = "claim_token_all", input = GetUrl)]
+pub async fn claim_token_all(address: String) -> Result<Vec<ClaimResponse>, ServerFnError> {
+    let mut results = Vec::with_capacity(2);
+
+    match claim_token(FaucetInfo::CalibnetUSDFC, address.clone()).await {
+        Ok(resp) => results.push(resp),
+        Err(e) => results.push(ClaimResponse {
+            faucet: FaucetInfo::CalibnetUSDFC,
+            tx_hash: None,
+            error: Some(e),
+        }),
+    }
+
+    match claim_token(FaucetInfo::CalibnetFIL, address).await {
+        Ok(resp) => results.push(resp),
+        Err(e) => results.push(ClaimResponse {
+            faucet: FaucetInfo::CalibnetFIL,
+            tx_hash: None,
+            error: Some(e),
+        }),
+    }
+
+    Ok(results)
 }
 
 #[cfg(feature = "ssr")]
@@ -279,7 +315,7 @@ async fn handle_native_claim(
     recipient: Address,
     from: Address,
     rpc: crate::utils::rpc_context::Provider,
-) -> Result<String, ServerFnError> {
+) -> Result<ClaimResponse, ServerFnError> {
     use crate::utils::message::message_transfer;
 
     let id_address = rpc.lookup_id(recipient).await.unwrap_or_else(|_| {
@@ -313,7 +349,11 @@ async fn handle_native_claim(
                 .eth_get_transaction_hash_by_cid(cid)
                 .await
                 .map_err(ServerFnError::new)?;
-            Ok(tx_hash.to_string())
+            Ok(ClaimResponse {
+                faucet: faucet_info,
+                tx_hash: Some(tx_hash),
+                error: None,
+            })
         }
         Err(err) => Err(handle_faucet_error(err)),
     }
@@ -325,7 +365,7 @@ async fn handle_erc20_claim(
     recipient: Address,
     from: Address,
     rpc: crate::utils::rpc_context::Provider,
-) -> Result<String, ServerFnError> {
+) -> Result<ClaimResponse, ServerFnError> {
     use crate::utils::address::AddressAlloyExt;
 
     let eth_to = recipient.into_eth_address().map_err(ServerFnError::new)?;
@@ -341,7 +381,11 @@ async fn handle_erc20_claim(
                 .send_eth_transaction_signed(&signed)
                 .await
                 .map_err(ServerFnError::new)?;
-            Ok(tx_hash.to_string())
+            Ok(ClaimResponse {
+                faucet: faucet_info,
+                tx_hash: Some(tx_hash),
+                error: None,
+            })
         }
         Err(err) => Err(handle_faucet_error(err)),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ mod ssr_imports {
         server_fn::axum::register_explicit::<faucet::server_api::SignedErc20Transfer>();
         server_fn::axum::register_explicit::<faucet::server_api::FaucetAddress>();
         server_fn::axum::register_explicit::<faucet::server_api::ClaimToken>();
+        server_fn::axum::register_explicit::<faucet::server_api::ClaimTokenAll>();
     }
 
     #[event(fetch)]

--- a/src/utils/address.rs
+++ b/src/utils/address.rs
@@ -108,7 +108,9 @@ impl AddressAlloyExt for Address {
                 error!(
                     "Cannot convert address {self} to Ethereum address. Only ID and Delegated addresses are supported."
                 );
-                bail!("Address {self} not supported.");
+                bail!(
+                    "Invalid address {self}, Only ID and Delegated addresses are supported."
+                );
             }
         }
     }

--- a/src/utils/address.rs
+++ b/src/utils/address.rs
@@ -108,9 +108,7 @@ impl AddressAlloyExt for Address {
                 error!(
                     "Cannot convert address {self} to Ethereum address. Only ID and Delegated addresses are supported."
                 );
-                bail!(
-                    "Invalid address {self}, Only ID and Delegated addresses are supported."
-                );
+                bail!("Invalid address {self}, Only ID and Delegated addresses are supported.");
             }
         }
     }

--- a/src/utils/address.rs
+++ b/src/utils/address.rs
@@ -108,7 +108,7 @@ impl AddressAlloyExt for Address {
                 error!(
                     "Cannot convert address {self} to Ethereum address. Only ID and Delegated addresses are supported."
                 );
-                bail!("invalid address {self}");
+                bail!("Address {self} not supported.");
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- Impl `/api/claim_token_all` API to requests claims for both `CalibnetUSDFC` and `CalibnetFIL` in one call.
- This api internally just calls `claim_token` and aggregates the results.

Preview URL: https://36c9a6e.forest-explorer-preview.workers.dev

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #333 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "claim all" API to request multiple faucet tokens in one call and receive per-claim JSON results (success items include faucet info and tx hash; failures include faucet info and error).

* **Documentation**
  * Updated API docs with the new endpoint, JSON array success/failure examples, multi-item responses, Key Points, and rate-limit info; original API docs now include additional success examples and references to the All API.

* **Bug Fixes**
  * Clarified address validation error messaging to specify supported address types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->