### PR TITLE
Restrict addresses on Calibnet USDFC faucet

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -87,7 +87,7 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token?faucet_info=Calibnet
 **Response:**
 
 ```bash
-ServerError|Invalid address: Not a valid Testnet address
+ServerError|Invalid address - failed to parse: Not a valid Testnet address
 ```
 
 #### 429 Too Many Requests
@@ -241,13 +241,13 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?address=invalida
   {
     "faucet_info": "CalibnetUSDFC",
     "error": {
-      "ServerError": "Invalid address: Not a valid Testnet address"
+      "ServerError": "Invalid address - failed to parse: Not a valid Testnet address"
     }
   },
   {
     "faucet_info": "CalibnetFIL",
     "error": {
-      "ServerError": "Invalid address: Not a valid Testnet address"
+      "ServerError": "Invalid address - failed to parse: Not a valid Testnet address"
     }
   }
 ]

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -291,6 +291,8 @@ curl "https://forest-explorer.chainsafe.dev/api/claim_token_all?address=0xAe9C4b
 
 - Each address is subject to rate limiting to prevent abuse.
 - This API only distributes Calibnet `tFIL` and `tUSDFC` tokens.
+- ID address or its corresponding eth style `0xff…ID` address are restricted to
+  claim `tUSDFC` tokens.
 
 ## Rate Limits
 

--- a/e2e/test_claim_token_api_config.js
+++ b/e2e/test_claim_token_api_config.js
@@ -296,43 +296,21 @@ export const TEST_SCENARIOS = {
       waitBefore: 0, // No wait needed, should be capped, already from the previous step
       walletCapErrorResponse: true,
     },
-
-    // TODO(forest-explorer): https://github.com/ChainSafe/forest-explorer/issues/335
-    //                       Token sent to the t0 and it's eth mapping address 0x
-    //                       are not accessible. Hence commenting out the following
-    //                       test cases.
-    // === CalibnetUSDFC ID Wallet (fresh wallet, 0 transactions) ===
-    // {
-    //   name: 'CalibnetUSDFC (ID) - 1st SUCCESS (fresh wallet)',
-    //   faucet_info: FaucetTypes.CalibnetUSDFC,
-    //   address: TEST_ADDRESSES.ETH_ID_CORRESPONDING,
-    //   expectedStatus: STATUS_CODES.SUCCESS,
-    //   waitBefore: 65, // Wait for cooldown from the previous test group to expire
-    //   walletCapErrorResponse: false,
-    // },
-    // {
-    //   name: 'CalibnetUSDFC (ID) - 2nd SUCCESS (reaches cap)',
-    //   faucet_info: FaucetTypes.CalibnetUSDFC,
-    //   address: TEST_ADDRESSES.ETH_ID_CORRESPONDING,
-    //   expectedStatus: STATUS_CODES.SUCCESS,
-    //   waitBefore: 65, // Wait for cooldown from its own 1st transaction
-    //   walletCapErrorResponse: false,
-    // },
-    // {
-    //   name: 'CalibnetUSDFC (ID) - 3rd attempt (WALLET CAPPED)',
-    //   faucet_info: FaucetTypes.CalibnetUSDFC,
-    //   address: TEST_ADDRESSES.ETH_ID_CORRESPONDING,
-    //   expectedStatus: STATUS_CODES.TOO_MANY_REQUESTS,
-    //   waitBefore: 65, // Wait for cooldown from its own 2nd transaction
-    //   walletCapErrorResponse: true,
-    // },
-    // {
-    //   name: 'CalibnetUSDFC (t0) - check equivalence (WALLET CAPPED)',
-    //   faucet_info: FaucetTypes.CalibnetUSDFC,
-    //   address: TEST_ADDRESSES.T0_ADDRESS, // This is the same wallet as the ID address
-    //   expectedStatus: STATUS_CODES.TOO_MANY_REQUESTS,
-    //   waitBefore: 0, // No wait needed, should be capped already
-    //   walletCapErrorResponse: true,
-    // },
+    {
+      name: 'CalibnetUSDFC (0xff...ID) - restricted address (RESTRICTED)',
+      faucet_info: FaucetTypes.CalibnetUSDFC,
+      address: TEST_ADDRESSES.ETH_ID_CORRESPONDING,
+      expectedStatus: STATUS_CODES.BAD_REQUEST,
+      waitBefore: 0, // No wait needed, should be restricted immediately.
+      walletCapErrorResponse: false,
+    },
+    {
+      name: 'CalibnetUSDFC (t0) - restricted address (RESTRICTED)',
+      faucet_info: FaucetTypes.CalibnetUSDFC,
+      address: TEST_ADDRESSES.T0_ADDRESS,
+      expectedStatus: STATUS_CODES.BAD_REQUEST,
+      waitBefore: 0, // No wait needed, should be restricted immediately.
+      walletCapErrorResponse: false,
+    },
   ]
 };

--- a/e2e/test_claim_token_api_config.js
+++ b/e2e/test_claim_token_api_config.js
@@ -186,19 +186,6 @@ export const TEST_SCENARIOS = {
       faucet_info: FaucetTypes.CalibnetUSDFC,
       address: TEST_ADDRESSES.T410_ADDRESS,
       expectedStatus: STATUS_CODES.TOO_MANY_REQUESTS
-    },
-    {
-      name: 'CalibnetUSDFC (t0) - RATE LIMITED (within CalibnetUSDFC cooldown)',
-      faucet_info: FaucetTypes.CalibnetUSDFC,
-      address: TEST_ADDRESSES.T0_ADDRESS,
-      expectedStatus: STATUS_CODES.TOO_MANY_REQUESTS
-    },
-    // CalibnetUSDFC doesn't support the t1 format address
-    {
-      name: 'CalibnetUSDFC (ID) - RATE LIMITED (within CalibnetUSDFC cooldown)',
-      faucet_info: FaucetTypes.CalibnetUSDFC,
-      address: TEST_ADDRESSES.ETH_ID_CORRESPONDING,
-      expectedStatus: STATUS_CODES.TOO_MANY_REQUESTS
     }
   ],
 

--- a/e2e/test_claim_token_api_config.js
+++ b/e2e/test_claim_token_api_config.js
@@ -136,7 +136,21 @@ export const TEST_SCENARIOS = {
       name: 'Invalid address format for CalibnetUSDFC',
       faucet_info: FaucetTypes.CalibnetUSDFC,
       address: TEST_ADDRESSES.T1_FORMAT_ADDRESS,
-      expectedStatus: STATUS_CODES.INTERNAL_SERVER_ERROR,
+      expectedStatus: STATUS_CODES.BAD_REQUEST,
+      expectedErrorContains: 'invalid address'
+    },
+    {
+      name: 'CalibnetUSDFC (0xff...ID) - restricted address (RESTRICTED)',
+      faucet_info: FaucetTypes.CalibnetUSDFC,
+      address: TEST_ADDRESSES.ETH_ID_CORRESPONDING,
+      expectedStatus: STATUS_CODES.BAD_REQUEST,
+      expectedErrorContains: 'invalid address'
+    },
+    {
+      name: 'CalibnetUSDFC (t0) - restricted address (RESTRICTED)',
+      faucet_info: FaucetTypes.CalibnetUSDFC,
+      address: TEST_ADDRESSES.T0_ADDRESS,
+      expectedStatus: STATUS_CODES.BAD_REQUEST,
       expectedErrorContains: 'invalid address'
     }
   ],
@@ -298,6 +312,6 @@ export const TEST_SCENARIOS = {
       expectedStatus: STATUS_CODES.BAD_REQUEST,
       waitBefore: 0, // No wait needed, should be restricted immediately.
       walletCapErrorResponse: false,
-    },
+    }
   ]
 };

--- a/e2e/test_claim_token_api_config.js
+++ b/e2e/test_claim_token_api_config.js
@@ -296,22 +296,6 @@ export const TEST_SCENARIOS = {
       expectedStatus: STATUS_CODES.TOO_MANY_REQUESTS,
       waitBefore: 0, // No wait needed, should be capped, already from the previous step
       walletCapErrorResponse: true,
-    },
-    {
-      name: 'CalibnetUSDFC (0xff...ID) - restricted address (RESTRICTED)',
-      faucet_info: FaucetTypes.CalibnetUSDFC,
-      address: TEST_ADDRESSES.ETH_ID_CORRESPONDING,
-      expectedStatus: STATUS_CODES.BAD_REQUEST,
-      waitBefore: 0, // No wait needed, should be restricted immediately.
-      walletCapErrorResponse: false,
-    },
-    {
-      name: 'CalibnetUSDFC (t0) - restricted address (RESTRICTED)',
-      faucet_info: FaucetTypes.CalibnetUSDFC,
-      address: TEST_ADDRESSES.T0_ADDRESS,
-      expectedStatus: STATUS_CODES.BAD_REQUEST,
-      waitBefore: 0, // No wait needed, should be restricted immediately.
-      walletCapErrorResponse: false,
     }
   ]
 };

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -427,7 +427,7 @@ fn set_response_status(status: StatusCode) {
     leptos::prelude::expect_context::<ResponseOptions>().set_status(status);
 }
 
-#[cfg(feature = "ssr")]
+#[cfg(all(test, feature = "ssr"))]
 mod tests {
     #[allow(unused_macros)]
     macro_rules! assert_address {

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -457,7 +457,7 @@ mod tests {
             "0xAe9C4b9508c929966ef37209b336E5796D632CDc",
         ];
         for addr in addresses.iter() {
-            assert_valid_address(*addr, FaucetInfo::MainnetFIL);
+            assert_valid_address(addr, FaucetInfo::MainnetFIL);
         }
     }
 
@@ -473,7 +473,7 @@ mod tests {
             "0xAe9C4b9508c929966ef37209b336E5796D632CDc",
         ];
         for addr in addresses.iter() {
-            assert_valid_address(*addr, FaucetInfo::CalibnetFIL);
+            assert_valid_address(addr, FaucetInfo::CalibnetFIL);
         }
     }
 
@@ -492,11 +492,11 @@ mod tests {
         ];
 
         for addr in valid_addresses.iter() {
-            assert_valid_address(*addr, FaucetInfo::CalibnetUSDFC);
+            assert_valid_address(addr, FaucetInfo::CalibnetUSDFC);
         }
 
         for addr in invalid_addresses.iter() {
-            assert_invalid_address(*addr, FaucetInfo::CalibnetUSDFC);
+            assert_invalid_address(addr, FaucetInfo::CalibnetUSDFC);
         }
     }
 }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -274,11 +274,10 @@ pub async fn claim_token_all(address: String) -> Result<Vec<ClaimResponse>, Serv
 /// Checks if the provided address is valid for the faucet, ensuring invalid addresses are rejected.
 #[cfg(feature = "ssr")]
 fn check_valid_address(address: Address, faucet_info: FaucetInfo) -> Result<(), ServerFnError> {
-    use crate::utils::address::AddressAlloyExt;
     use fvm_shared::address::Protocol;
 
     if matches!(faucet_info, FaucetInfo::CalibnetUSDFC)
-        && (address.protocol() == Protocol::ID || address.into_eth_address().is_err())
+        && (address.protocol() != Protocol::Delegated)
     {
         log::error!("Invalid address: {:?}", address);
         set_response_status(StatusCode::BAD_REQUEST);

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -281,9 +281,7 @@ fn check_valid_address(address: Address, faucet_info: FaucetInfo) -> Result<(), 
         && (address.protocol() == Protocol::ID || address.into_eth_address().is_err())
     {
         log::error!("Invalid address: {:?}", address);
-        if leptos::context::use_context::<ResponseOptions>().is_some() {
-            set_response_status(StatusCode::BAD_REQUEST);
-        }
+        set_response_status(StatusCode::BAD_REQUEST);
         return Err(ServerFnError::ServerError("Invalid address: Only Ethereum-compatible addresses (delegated t4 addresses or native Ethereum 0x addresses) are allowed for Calibnet USDFC token claims.".to_string()));
     }
     Ok(())
@@ -424,7 +422,7 @@ fn handle_faucet_error(err: FaucetError) -> ServerFnError {
 
 #[cfg(feature = "ssr")]
 fn set_response_status(status: StatusCode) {
-    leptos::prelude::expect_context::<ResponseOptions>().set_status(status);
+    leptos::context::use_context::<ResponseOptions>().map(|res| res.set_status(status));
 }
 
 #[cfg(all(test, feature = "ssr"))]

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -273,6 +273,7 @@ pub async fn claim_token_all(address: String) -> Result<Vec<ClaimResponse>, Serv
 
 #[cfg(feature = "ssr")]
 fn is_address_restricted(address: &str, faucet_info: FaucetInfo) -> bool {
+    let address = address.trim().to_lowercase();
     matches!(faucet_info, FaucetInfo::CalibnetUSDFC)
         && (address.starts_with("0xff000000000000000000000000") || address.starts_with("t0"))
 }
@@ -285,7 +286,7 @@ fn parse_and_validate_address(
     if is_address_restricted(address, faucet_info) {
         log::error!("Restricted address: {}", address);
         set_response_status(StatusCode::BAD_REQUEST);
-        return Err(ServerFnError::ServerError("Use of ID address or it's corresponding Ethereum style 0xff...ID address is restricted to claim tokens from CalibnetUSFC faucet.".to_string()));
+        return Err(ServerFnError::ServerError("Use of ID addresses or their corresponding Ethereum style 0xff...ID addresses is restricted when claiming tokens from the CalibnetUSDFC faucet.".to_string()));
     }
     match crate::utils::address::parse_address(address, faucet_info.network()) {
         Ok(addr) => Ok(addr),

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -435,11 +435,17 @@ mod tests {
             let network = $faucet.network();
             let addr = crate::utils::address::parse_address($address, network).unwrap();
             assert!(crate::faucet::server_api::check_valid_address(addr, $faucet).is_ok());
+            assert!(
+                crate::faucet::server_api::parse_and_validate_address($address, $faucet).is_ok()
+            );
         }};
         ($address:expr, $faucet:expr, false) => {{
             let network = $faucet.network();
             let addr = crate::utils::address::parse_address($address, network).unwrap();
             assert!(crate::faucet::server_api::check_valid_address(addr, $faucet).is_err());
+            assert!(
+                crate::faucet::server_api::parse_and_validate_address($address, $faucet).is_err()
+            );
         }};
     }
 

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -284,7 +284,7 @@ fn check_valid_address(address: Address, faucet_info: FaucetInfo) -> Result<(), 
         if leptos::context::use_context::<ResponseOptions>().is_some() {
             set_response_status(StatusCode::BAD_REQUEST);
         }
-        return Err(ServerFnError::ServerError("Invalid address: ID and 0xff...ID address formats are restricted for Calibnet USDFC token claims.".to_string()));
+        return Err(ServerFnError::ServerError("Invalid address: Only Ethereum-compatible addresses (delegated t4 addresses or native Ethereum 0x addresses) are allowed for Calibnet USDFC token claims.".to_string()));
     }
     Ok(())
 }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -422,12 +422,13 @@ fn handle_faucet_error(err: FaucetError) -> ServerFnError {
 
 #[cfg(feature = "ssr")]
 fn set_response_status(status: StatusCode) {
-    leptos::context::use_context::<ResponseOptions>().map(|res| res.set_status(status));
+    if let Some(res) = leptos::context::use_context::<ResponseOptions>() {
+        res.set_status(status)
+    }
 }
 
 #[cfg(all(test, feature = "ssr"))]
 mod tests {
-    #[allow(unused_macros)]
     macro_rules! assert_address {
         ($address:expr, $faucet:expr) => {{
             let network = $faucet.network();

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -284,7 +284,7 @@ fn check_valid_address(address: Address, faucet_info: FaucetInfo) -> Result<(), 
         if leptos::context::use_context::<ResponseOptions>().is_some() {
             set_response_status(StatusCode::BAD_REQUEST);
         }
-        return Err(ServerFnError::ServerError("Use of ID addresses or their corresponding Ethereum style 0xff...ID addresses is restricted when claiming tokens from the CalibnetUSDFC faucet.".to_string()));
+        return Err(ServerFnError::ServerError("Invalid address: ID and 0xff...ID address formats are restricted for Calibnet USDFC token claims.".to_string()));
     }
     Ok(())
 }
@@ -300,10 +300,10 @@ fn parse_and_validate_address(
             Ok(addr)
         }
         Err(e) => {
-            log::error!("Failed to parse address: {}", e);
+            log::error!("Invalid address - failed to parse: {}", e);
             set_response_status(StatusCode::BAD_REQUEST);
             Err(ServerFnError::ServerError(format!(
-                "Failed to parse address: {}",
+                "Invalid address - failed to parse: {}",
                 e
             )))
         }

--- a/src/faucet/server_api.rs
+++ b/src/faucet/server_api.rs
@@ -429,23 +429,20 @@ fn set_response_status(status: StatusCode) {
 
 #[cfg(all(test, feature = "ssr"))]
 mod tests {
-    macro_rules! assert_address {
-        ($address:expr, $faucet:expr) => {{
-            let network = $faucet.network();
-            let addr = crate::utils::address::parse_address($address, network).unwrap();
-            assert!(crate::faucet::server_api::check_valid_address(addr, $faucet).is_ok());
-            assert!(
-                crate::faucet::server_api::parse_and_validate_address($address, $faucet).is_ok()
-            );
-        }};
-        ($address:expr, $faucet:expr, false) => {{
-            let network = $faucet.network();
-            let addr = crate::utils::address::parse_address($address, network).unwrap();
-            assert!(crate::faucet::server_api::check_valid_address(addr, $faucet).is_err());
-            assert!(
-                crate::faucet::server_api::parse_and_validate_address($address, $faucet).is_err()
-            );
-        }};
+    use crate::faucet::server_api::*;
+
+    fn assert_valid_address(address: &str, faucet: FaucetInfo) {
+        let network = faucet.network();
+        let addr = crate::utils::address::parse_address(address, network).unwrap();
+        assert!(check_valid_address(addr, faucet).is_ok());
+        assert!(parse_and_validate_address(address, faucet).is_ok());
+    }
+
+    fn assert_invalid_address(address: &str, faucet: FaucetInfo) {
+        let network = faucet.network();
+        let addr = crate::utils::address::parse_address(address, network).unwrap();
+        assert!(check_valid_address(addr, faucet).is_err());
+        assert!(parse_and_validate_address(address, faucet).is_err());
     }
 
     #[test]
@@ -460,7 +457,7 @@ mod tests {
             "0xAe9C4b9508c929966ef37209b336E5796D632CDc",
         ];
         for addr in addresses.iter() {
-            assert_address!(*addr, crate::faucet::server_api::FaucetInfo::MainnetFIL);
+            assert_valid_address(*addr, FaucetInfo::MainnetFIL);
         }
     }
 
@@ -476,7 +473,7 @@ mod tests {
             "0xAe9C4b9508c929966ef37209b336E5796D632CDc",
         ];
         for addr in addresses.iter() {
-            assert_address!(*addr, crate::faucet::server_api::FaucetInfo::CalibnetFIL);
+            assert_valid_address(*addr, FaucetInfo::CalibnetFIL);
         }
     }
 
@@ -495,15 +492,11 @@ mod tests {
         ];
 
         for addr in valid_addresses.iter() {
-            assert_address!(*addr, crate::faucet::server_api::FaucetInfo::CalibnetUSDFC);
+            assert_valid_address(*addr, FaucetInfo::CalibnetUSDFC);
         }
 
         for addr in invalid_addresses.iter() {
-            assert_address!(
-                *addr,
-                crate::faucet::server_api::FaucetInfo::CalibnetUSDFC,
-                false
-            );
+            assert_invalid_address(*addr, FaucetInfo::CalibnetUSDFC);
         }
     }
 }

--- a/src/utils/address.rs
+++ b/src/utils/address.rs
@@ -63,7 +63,7 @@ pub fn parse_address(raw: &str, n: Network) -> anyhow::Result<Address> {
             s.chars().skip(2).all(|c| c.is_ascii_hexdigit()),
             "Invalid characters in address"
         );
-        if let Some(id) = s.strip_prefix("0xff") {
+        if let Some(id) = s.strip_prefix("0xff0000000000000000000000") {
             let id = u64::from_str_radix(id, 16)?;
             Ok(Address::new_id(id))
         } else {


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- `tUSDFC` tokens claimed for ID address or it's corresponding eth style `0xff...ID` address are not accessible so this PR  restricts these addresses on `CalibnetUSDFC` faucet.
- added test

Preview URL: https://1432c3b.forest-explorer-preview.workers.dev

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes #335 

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

<!-- Please add a changelog entry for your change if needed. -->
<!-- Follow this format https://keepachangelog.com/en/1.0.0/ -->

- [X] I have performed a self-review of my own code,
- [X] I have made corresponding changes to the documentation. All new code
      adheres to the team's
      [documentation standards](https://github.com/ChainSafe/forest/wiki/Documentation-practices),
- [X] I have added tests that prove my fix is effective or that my feature works
      (if possible),
- [X] I have made sure the [CHANGELOG][1] is up-to-date. All user-facing changes
      should be reflected in this document.

<!-- Thank you 🔥 -->

[1]: https://github.com/ChainSafe/forest-explorer/blob/main/CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calibnet tUSDFC now immediately rejects restricted address types (ID-style 0xff… and t0) with BAD_REQUEST and clearer "Invalid address - failed to parse: Not a valid Testnet address" messaging.
  * 0x‑prefixed addresses parsed more strictly to avoid false-ID interpretations and improve validation.

* **Documentation**
  * API docs updated to note the Calibnet tUSDFC claiming restriction and revised error examples.

* **Tests**
  * E2E and unit tests updated to expect immediate rejection; removed prior rate‑limit and wallet‑capacity scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->